### PR TITLE
Require Application Date when not 'Send Later' — backend validation and frontend form check

### DIFF
--- a/src/main/java/com/jobtracker/service/ApplicationService.java
+++ b/src/main/java/com/jobtracker/service/ApplicationService.java
@@ -170,11 +170,17 @@ public class ApplicationService {
     public List<ApplicationResponse> getOverdue() {
         UUID userId = securityUtils.getCurrentUserId();
         LocalDateTime reminderThreshold = LocalDateTime.now().minusHours(6);
-        return applicationRepository.findOverdueByUserId(userId, reminderThreshold)
+        LocalDateTime expireThreshold = LocalDateTime.now().minusDays(2);
+        return applicationRepository.findOverdueByUserId(userId, reminderThreshold, expireThreshold)
                 .stream().map(applicationMapper::toResponse).toList();
     }
 
     private void mapRequestToEntity(ApplicationRequest request, JobApplication app) {
+        boolean isSendLater = request.status() == null || request.status().isBlank();
+        if (!isSendLater && request.applicationDate() == null) {
+            throw new BadRequestException("Application date is required when 'Send Later' is not marked");
+        }
+
         app.setVacancyName(normalizeOptionalText(request.vacancyName()));
         app.setRecruiterName(request.recruiterName());
         app.setOrganization(request.organization());


### PR DESCRIPTION
Backend: require applicationDate when application is not marked as 'To send later'.
Frontend: client-side validation prevents submit when Application Date is missing unless 'To send later' is enabled.

Closes #19

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>