### PR TITLE
ci: surface surefire failures in backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,6 +46,36 @@ jobs:
       - name: Run tests and package JAR
         run: mvn -B -ntp clean verify
 
+      - name: Print Surefire report summary on failure
+        if: failure()
+        run: |
+          if [ -d target/surefire-reports ]; then
+            echo "Collected Surefire reports:"
+            find target/surefire-reports -maxdepth 1 -type f \( -name '*.txt' -o -name '*.xml' \)
+            echo
+            for report in target/surefire-reports/*.txt; do
+              [ -f "$report" ] || continue
+              echo "===== $report ====="
+              sed -n '1,200p' "$report"
+              echo
+            done
+          else
+            echo "No target/surefire-reports directory found."
+          fi
+
+      - name: Upload Surefire reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: |
+            target/surefire-reports/**
+            **/*.dump
+            **/*-jvmRun*.dump
+            **/*.dumpstream
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload packaged JAR
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Motivation
- Make test failures from the Maven Surefire plugin immediately diagnosable by printing a concise report summary into CI logs when tests fail.
- Preserve full Surefire and JVM dump artifacts for post-failure analysis by uploading them as artifacts.
- Reduce developer turnaround by surfacing failure details in the workflow so rerunning locally is less often required.

### Description
- Updated `.github/workflows/backend.yml` to add a failure-only step `Print Surefire report summary on failure` that prints the contents of files in `target/surefire-reports` (first 200 lines of `*.txt`) into the Action log.
- Added a failure-only artifact upload step `Upload Surefire reports` using `actions/upload-artifact@v4` to archive `target/surefire-reports/**` and JVM dump files (`*.dump`, `*-jvmRun*.dump`, `*.dumpstream`).
- Left the existing packaged JAR upload step and normal build/test step (`mvn -B -ntp clean verify`) unchanged.

### Testing
- Verified the workflow YAML structure and the new steps by inspecting `.github/workflows/backend.yml` after the edit.
- Ran `mvn test -q` in the local environment which failed due to external dependency resolution (`org.springframework.boot:spring-boot-starter-parent:3.2.5` could not be fetched from Maven Central with HTTP 403), so end-to-end CI test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148a674fe883238979909c20f6ac72)