### PR TITLE
fix: resolve test compilation errors and update tests for PDF support

### DIFF
--- a/src/test/java/com/jobtracker/integration/GoogleDriveControllerIT.java
+++ b/src/test/java/com/jobtracker/integration/GoogleDriveControllerIT.java
@@ -236,20 +236,20 @@ class GoogleDriveControllerIT extends AbstractIntegrationTest {
     }
 
     @Test
-    void addBaseResume_shouldRejectNonGoogleDocsFile() throws Exception {
+    void addBaseResume_shouldRejectUnsupportedFileType() throws Exception {
         googleDriveConnectionRepository.save(buildConnection());
-        googleDriveApiClient.fileMetadataById.put("pdf-file",
+        googleDriveApiClient.fileMetadataById.put("docx-file",
                 new GoogleDriveApiClient.DriveFileMetadata(
-                        "pdf-file",
-                        "Resume.pdf",
-                        "application/pdf",
+                        "docx-file",
+                        "Resume.docx",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                         null
                 ));
 
         mockMvc.perform(post("/api/v1/google-drive/base-resumes")
                         .header("Authorization", "Bearer " + betaAccessToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"documentIdOrUrl\":\"pdf-file\"}"))
+                        .content("{\"documentIdOrUrl\":\"docx-file\"}"))
                 .andExpect(status().isBadRequest());
     }
 
@@ -670,6 +670,11 @@ class GoogleDriveControllerIT extends AbstractIntegrationTest {
         @Override
         public DriveFileMetadata exportGoogleDocAsPdf(String accessToken, String documentId, String targetFolderId, String pdfName) {
             return new DriveFileMetadata("pdf-file", pdfName, "application/pdf", null);
+        }
+
+        @Override
+        public byte[] downloadFileBytes(String accessToken, String fileId) {
+            return new byte[0];
         }
     }
 }

--- a/src/test/java/com/jobtracker/integration/mcp/McpAuthIT.java
+++ b/src/test/java/com/jobtracker/integration/mcp/McpAuthIT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobtracker.dto.auth.AuthResponse;
 import com.jobtracker.dto.auth.RegisterRequest;
 import com.jobtracker.integration.AbstractIntegrationTest;
+import com.jobtracker.repository.GoogleDriveConnectionRepository;
 import com.jobtracker.repository.RefreshTokenRepository;
 import com.jobtracker.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,11 +49,13 @@ class McpAuthIT extends AbstractIntegrationTest {
     @Autowired private ObjectMapper objectMapper;
     @Autowired private UserRepository userRepository;
     @Autowired private RefreshTokenRepository refreshTokenRepository;
+    @Autowired private GoogleDriveConnectionRepository googleDriveConnectionRepository;
 
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        googleDriveConnectionRepository.deleteAll();
         refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
 

--- a/src/test/java/com/jobtracker/unit/GoogleDriveServiceTest.java
+++ b/src/test/java/com/jobtracker/unit/GoogleDriveServiceTest.java
@@ -143,20 +143,20 @@ class GoogleDriveServiceTest {
     }
 
     @Test
-    void addBaseResume_shouldRejectNonGoogleDocsFiles() {
+    void addBaseResume_shouldRejectUnsupportedFileTypes() {
         when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
         when(connectionRepository.findByUserId(USER_ID)).thenReturn(Optional.of(connection));
         when(googleDriveApiClient.getFileMetadata("access-token", "not-a-doc"))
                 .thenReturn(new GoogleDriveApiClient.DriveFileMetadata(
                         "not-a-doc",
-                        "Resume.pdf",
-                        "application/pdf",
+                        "Resume.docx",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                         null
                 ));
 
         assertThatThrownBy(() -> googleDriveService.addBaseResume(new GoogleDriveBaseResumeRequest("not-a-doc", null, false)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("Only Google Docs base resumes are supported");
+                .hasMessageContaining("Only Google Docs documents and PDF files are supported");
     }
 
     @Test

--- a/src/test/java/com/jobtracker/unit/mcp/McpResumeContentResourcesTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpResumeContentResourcesTest.java
@@ -31,7 +31,7 @@ class McpResumeContentResourcesTest {
     @Test
     void baseResumeContent_readsRequestedResourceAndReturnsText() {
         UUID resumeId = UUID.randomUUID();
-        BaseResumeContentResponse response = new BaseResumeContentResponse(resumeId, "Base CV", "EN", true, "base-text");
+        BaseResumeContentResponse response = new BaseResumeContentResponse(resumeId, "Base CV", "EN", true, false, "base-text");
         when(resumeGenerationService.getBaseResumeContent(resumeId)).thenReturn(response);
 
         String result = baseResumeContentResource.baseResumeContent(resumeId.toString());


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Fix compilation error**: `FakeGoogleDriveApiClient` was missing the `downloadFileBytes(String, String)` override required by the `GoogleDriveApiClient` interface
- **Fix compilation error**: `BaseResumeContentResponse` constructor in `McpResumeContentResourcesTest` was missing the new `readOnly` boolean argument (record now has 6 fields)
- **Fix failing tests**: `addBaseResume_shouldRejectNonGoogleDocsFile(s)` tests were still asserting PDFs are rejected, but production code was updated to accept PDFs as read-only resumes — updated tests to use an unsupported MIME type (`application/vnd.openxmlformats-officedocument.wordprocessingml.document`) instead
- **Fix failing tests**: `McpAuthIT.setUp` was throwing a `DataIntegrityViolation` when calling `userRepository.deleteAll()` because leftover `google_drive_connections` records (FK to users) were not cleaned up — added `googleDriveConnectionRepository.deleteAll()` before deleting users

## Test plan

- [x] `mvn clean verify` passes with 0 failures, 0 errors
- [x] `GoogleDriveControllerIT` — all tests green
- [x] `GoogleDriveServiceTest` — all tests green
- [x] `McpResumeContentResourcesTest` — all tests green
- [x] `McpAuthIT` — all 4 tests green

https://claude.ai/code/session_01WsXBePpMyKd57McmFAyyTQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsXBePpMyKd57McmFAyyTQ)_