### PR TITLE
Add atomic resume generation endpoint for job applications

### DIFF
--- a/src/main/java/com/jobtracker/dto/gdrive/ResumePlaceholderResponse.java
+++ b/src/main/java/com/jobtracker/dto/gdrive/ResumePlaceholderResponse.java
@@ -45,6 +45,9 @@ public record ResumePlaceholderResponse(
         List<String> placeholders,
 
         @Schema(description = "Timestamp when the resume was generated", example = "2024-06-01T12:34:56")
-        LocalDateTime generatedAt
+        LocalDateTime generatedAt,
+
+        @Schema(description = "True once the document and PDF have both been generated and linked to the application", example = "true")
+        boolean workflowCompleted
 ) {
 }

--- a/src/main/java/com/jobtracker/entity/JobApplication.java
+++ b/src/main/java/com/jobtracker/entity/JobApplication.java
@@ -105,6 +105,15 @@ public class JobApplication {
     @Column(name = "drive_resume_generated_at")
     private LocalDateTime driveResumeGeneratedAt;
 
+    @Column(name = "drive_resume_template_id", columnDefinition = "BINARY(16)")
+    private UUID driveResumeTemplateId;
+
+    @Column(name = "drive_resume_pdf_file_id", length = 255)
+    private String driveResumePdfFileId;
+
+    @Column(name = "drive_resume_pdf_url", length = 2048)
+    private String driveResumePdfUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -212,6 +221,15 @@ public class JobApplication {
 
     public LocalDateTime getDriveResumeGeneratedAt() { return driveResumeGeneratedAt; }
     public void setDriveResumeGeneratedAt(LocalDateTime driveResumeGeneratedAt) { this.driveResumeGeneratedAt = driveResumeGeneratedAt; }
+
+    public UUID getDriveResumeTemplateId() { return driveResumeTemplateId; }
+    public void setDriveResumeTemplateId(UUID driveResumeTemplateId) { this.driveResumeTemplateId = driveResumeTemplateId; }
+
+    public String getDriveResumePdfFileId() { return driveResumePdfFileId; }
+    public void setDriveResumePdfFileId(String driveResumePdfFileId) { this.driveResumePdfFileId = driveResumePdfFileId; }
+
+    public String getDriveResumePdfUrl() { return driveResumePdfUrl; }
+    public void setDriveResumePdfUrl(String driveResumePdfUrl) { this.driveResumePdfUrl = driveResumePdfUrl; }
 
     public User getUser() { return user; }
     public void setUser(User user) { this.user = user; }

--- a/src/main/java/com/jobtracker/mcp/resources/McpResumeWorkflowRulesResource.java
+++ b/src/main/java/com/jobtracker/mcp/resources/McpResumeWorkflowRulesResource.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class McpResumeWorkflowRulesResource {
 
-    private static final String LAST_MODIFIED = "2026-06-13";
+    private static final String LAST_MODIFIED = "2026-07-13";
 
     @McpResource(
             uri = McpResourcesConfig.URI_RESUME_WORKFLOW_RULES,
@@ -28,6 +28,13 @@ public class McpResumeWorkflowRulesResource {
         return """
                 # Resume Workflow Rules
 
+                MANDATORY ROUTING RULE: every job-related CV/resume request MUST be executed through this MCP
+                server's resume tools. Never use generic document, filesystem, Python, DOCX, PDF, or non-MCP
+                Google Drive tools to produce or edit a resume — not even as a fallback when a tool call fails.
+                If a tool fails, surface the error to the user and retry or ask for missing input; do not
+                silently switch to local file generation. A resume request is only complete once this MCP
+                server returns a documentUrl and pdfUrl linked to the application.
+
                 Execute these steps in order:
 
                 1. Read my base information FIRST (mandatory, top priority). Call List-Base-Information and read every
@@ -36,12 +43,16 @@ public class McpResumeWorkflowRulesResource {
                    before generating any CV content. If no base information exists, fall back to step 2.
                 2. (Secondary) List-Applications — find the newest application with a non-empty driveResumeFileId and read
                    resource://job-apply-tracker/generated-resume/{applicationId} as a supplementary CV source.
-                3. Call List-Base-Resumes — pick the template by vacancy language (PT → PT-BR template, EN → EN-US template).
-                   Alternatively read resource://job-apply-tracker/base-resumes if the tool is unavailable.
-                4. Detect-Resume-Placeholders — call this before Generate-Resume every time.
+                3. Create-Application — save the application before generating the tailored resume.
+                4. Detect-Resume-Placeholders (via List-Base-Resumes first if you need to inspect placeholders or
+                   disambiguate templates before submitting values) and gather a value for every placeholder.
                 5. Ask only for missing information that is required to fill placeholders or log the application.
-                6. Create-Application — save the application before generating the tailored resume.
-                7. Generate-Resume — provide every detected placeholder value.
+                6. Generate-Application-Resume — the preferred, atomic call once the applicationId and every
+                   placeholder value are known. Pass baseResumeId if known, or language to auto-select the
+                   template. It internally selects the template, detects and validates placeholders, generates
+                   the Google Doc and PDF, and links them to the application in one call. Use the low-level
+                   Copy-Resume-To-Application / Detect-Resume-Placeholders / Generate-Resume tools only for
+                   advanced/manual flows (e.g. inspecting an intermediate step).
 
                 Rules:
                 - ALWAYS read base information (step 1) before generating any CV content when any base information exists.
@@ -51,7 +62,8 @@ public class McpResumeWorkflowRulesResource {
                 - Placeholder keys must match Detect-Resume-Placeholders exactly, without curly braces.
                 - If neither base information nor a prior generated resume exists, ask the user for their CV text because
                   this MCP setup does not expose generic Drive search or file-read tools.
-                - If Generate-Resume fails, keep the application record and return the placeholder values.
+                - If Generate-Application-Resume (or Generate-Resume) fails, keep the application record, surface the
+                  error, and retry with corrected input — do not fall back to local generation.
 
                 ID disambiguation:
                 - baseResumeId: a Job Apply Tracker UUID returned by List-Base-Resumes or

--- a/src/main/java/com/jobtracker/mcp/tools/McpGoogleDriveTools.java
+++ b/src/main/java/com/jobtracker/mcp/tools/McpGoogleDriveTools.java
@@ -85,7 +85,12 @@ public class McpGoogleDriveTools {
                     Use List-Base-Resumes to obtain a valid baseResumeId before calling this tool. \
                     The baseResumeId is a Job Apply Tracker UUID — it is NOT a Google Drive file ID. \
                     The application folder is created automatically inside the configured Drive root folder \
-                    if it does not yet exist.""",
+                    if it does not yet exist.
+
+                    This is a low-level, advanced-use tool. For the normal "generate a tailored resume for \
+                    this application" request, call Generate-Application-Resume instead — it copies, fills \
+                    placeholders, and exports the PDF in one atomic call. Do NOT fall back to local DOCX/PDF \
+                    generation, filesystem, or non-MCP tools for job-related resumes.""",
             annotations = @McpAnnotations(
                     title = "Copy Resume To Application",
                     readOnlyHint = false,
@@ -133,6 +138,11 @@ public class McpGoogleDriveTools {
                     placeholders with the supplied values, export a PDF, and return links to both \
                     the Google Doc and the PDF.
 
+                    This is a low-level, advanced-use tool for callers that already ran List-Base-Resumes and \
+                    Detect-Resume-Placeholders themselves (e.g. to inspect placeholders before submitting values). \
+                    For the normal case, call Generate-Application-Resume instead — it selects the template, \
+                    detects and validates placeholders, and generates the resume in a single atomic call.
+
                     Prerequisites (call in order before this tool):
                     1. List-Base-Information + Get-Base-Information-Content — you MUST read the candidate's base \
                        information first. It is the authoritative source of truth about the candidate; never generate \
@@ -142,7 +152,8 @@ public class McpGoogleDriveTools {
                     4. Provide a value for every detected placeholder key (keys without braces, \
                        e.g. "RESUMO", "STACK", "PROJETO_1").
 
-                    Do NOT call this tool before Create-Application — you need the applicationId first.""",
+                    Do NOT call this tool before Create-Application — you need the applicationId first. \
+                    Local DOCX/PDF/filesystem generation is never a valid substitute for this workflow.""",
             annotations = @McpAnnotations(
                     title = "Generate Resume",
                     readOnlyHint = false,
@@ -159,6 +170,63 @@ public class McpGoogleDriveTools {
         return resumeGenerationService.generateTemplateResume(
                 UUID.fromString(applicationId),
                 new ResumePlaceholderRequest(UUID.fromString(baseResumeId), values));
+    }
+
+    @McpTool(
+            name = "Generate-Application-Resume",
+            title = "Generate Application Resume",
+            description = """
+                    MANDATORY entry point for "generate/tailor a resume for this application" requests. \
+                    Runs the full resume workflow atomically on the backend: selects the base resume template, \
+                    detects placeholders, validates every placeholder has a value, copies the template, replaces \
+                    placeholders, exports the PDF, and links both to the application — in one call.
+
+                    You MUST use this tool (or the low-level Copy-Resume-To-Application / \
+                    Detect-Resume-Placeholders / Generate-Resume sequence) for every job-related CV/resume request. \
+                    Never fall back to generic document, filesystem, Python, DOCX, PDF, or non-MCP Google Drive \
+                    tools to produce a resume — a request is not complete unless it returns a Google Doc \
+                    (documentUrl) and PDF (pdfUrl) linked to the application via this MCP server.
+
+                    Prerequisites before calling this tool:
+                    1. Create-Application — the application must already exist.
+                    2. List-Base-Information + Get-Base-Information-Content — read the candidate's base information \
+                       first; it is the authoritative source of truth. Never invent experience, skills, or projects.
+
+                    Template selection: pass baseResumeId (from List-Base-Resumes) to use a specific template, \
+                    or pass language (e.g. "PT", "EN") to let the backend pick the single matching reusable \
+                    template automatically. If zero or more than one template matches the language, the call \
+                    fails with a clear error asking you to pass baseResumeId explicitly — it never guesses.
+
+                    Placeholder values: supply a value for every placeholder in the template (keys without \
+                    braces). The call fails with a clear error listing any missing placeholder instead of \
+                    generating an incomplete resume. Read-only PDF resumes and mismatched applications also \
+                    fail with clear errors.
+
+                    Calling this tool again for the same application regenerates the resume: a new Google Doc \
+                    and PDF are created in the application's Drive folder and become the new linked resume; \
+                    the previous files remain in Drive but are no longer referenced by the application.
+
+                    On success the response always includes documentUrl, pdfUrl, baseResumeId (the template \
+                    used), and workflowCompleted: true.""",
+            annotations = @McpAnnotations(
+                    title = "Generate Application Resume",
+                    readOnlyHint = false,
+                    destructiveHint = false,
+                    idempotentHint = false,
+                    openWorldHint = true))
+    @AuditMcpOperation(action = "Generate-Application-Resume")
+    public ResumePlaceholderResponse generateApplicationResume(
+            McpSyncRequestContext ctx,
+            @McpToolParam(required = true, description = "UUID of the job application — must already exist (from Create-Application)") String applicationId,
+            @McpToolParam(required = false, description = "UUID of the base resume template — obtain from List-Base-Resumes, NOT a Google Drive file ID. Omit to select automatically by language.") String baseResumeId,
+            @McpToolParam(required = false, description = "Vacancy language code (e.g. \"PT\", \"EN\") used to auto-select the template when baseResumeId is omitted. Ignored if baseResumeId is provided.") String language,
+            @McpToolParam(required = true, description = "Placeholder values keyed by the exact names returned by Detect-Resume-Placeholders (without braces), e.g. {\"RESUMO\":\"...\", \"STACK\":\"Java, Spring Boot\"}. Every detected placeholder must have a value.")
+            Map<String, String> values) {
+        return resumeGenerationService.generateApplicationResume(
+                UUID.fromString(applicationId),
+                baseResumeId == null ? null : UUID.fromString(baseResumeId),
+                language,
+                values);
     }
 
     @McpTool(

--- a/src/main/java/com/jobtracker/service/ResumeGenerationService.java
+++ b/src/main/java/com/jobtracker/service/ResumeGenerationService.java
@@ -167,11 +167,15 @@ public class ResumeGenerationService {
                 pdfName
         );
         LocalDateTime generatedAt = LocalDateTime.now();
+        String pdfUrl = resolveDocumentLink(pdfFile);
 
         application.setDriveResumeFileId(copiedFile.id());
         application.setDriveResumeFileName(copiedFile.name());
         application.setDriveResumeDocumentUrl(copiedDocumentUrl);
         application.setDriveResumeGeneratedAt(generatedAt);
+        application.setDriveResumeTemplateId(baseResume.getId());
+        application.setDriveResumePdfFileId(pdfFile.id());
+        application.setDriveResumePdfUrl(pdfUrl);
 
         connectionRepository.save(connection);
         applicationRepository.save(application);
@@ -182,11 +186,62 @@ public class ResumeGenerationService {
                 copiedFile.id(),
                 pdfFile.id(),
                 copiedDocumentUrl,
-                resolveDocumentLink(pdfFile),
+                pdfUrl,
                 values,
                 remainingPlaceholders,
-                generatedAt
+                generatedAt,
+                true
         );
+    }
+
+    /**
+     * Atomic, agent-proof entry point for issue #61: resolves the template, validates every
+     * detected placeholder has a value, and generates the resume in a single call so the
+     * List-Base-Resumes / Detect-Resume-Placeholders / Generate-Resume sequence cannot be
+     * silently skipped or replaced by local file generation.
+     */
+    @Transactional
+    public ResumePlaceholderResponse generateApplicationResume(UUID applicationId, UUID explicitBaseResumeId, String language, Map<String, String> values) {
+        UUID userId = securityUtils.getCurrentUserId();
+        applicationRepository.findByIdAndUserId(applicationId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found with id: " + applicationId));
+
+        UUID baseResumeId = explicitBaseResumeId != null ? explicitBaseResumeId : selectBaseResumeIdByLanguage(userId, language);
+
+        List<String> placeholders = detectPlaceholders(baseResumeId).placeholders();
+        Map<String, String> safeValues = values == null ? Map.of() : values;
+        validateAllPlaceholdersProvided(placeholders, safeValues);
+
+        return generateTemplateResume(applicationId, new ResumePlaceholderRequest(baseResumeId, safeValues));
+    }
+
+    private UUID selectBaseResumeIdByLanguage(UUID userId, String language) {
+        if (!StringUtils.hasText(language)) {
+            throw new BadRequestException("Provide either baseResumeId or language to select a resume template");
+        }
+
+        List<GoogleDriveBaseResume> candidates = baseResumeRepository.findAllByConnectionUserIdOrderByCreatedAtAsc(userId).stream()
+                .filter(GoogleDriveBaseResume::isTemplate)
+                .filter(resume -> !resume.isReadOnly())
+                .filter(resume -> language.equalsIgnoreCase(resume.getLanguage()))
+                .toList();
+
+        if (candidates.isEmpty()) {
+            throw new BadRequestException("No reusable template found for language '" + language + "'. Use List-Base-Resumes and pass baseResumeId explicitly.");
+        }
+        if (candidates.size() > 1) {
+            throw new BadRequestException("Multiple templates found for language '" + language + "'. Pass baseResumeId explicitly to disambiguate.");
+        }
+        return candidates.get(0).getId();
+    }
+
+    private void validateAllPlaceholdersProvided(List<String> placeholders, Map<String, String> values) {
+        List<String> missing = placeholders.stream()
+                .filter(placeholder -> !StringUtils.hasText(values.get(placeholder)))
+                .toList();
+        if (!missing.isEmpty()) {
+            throw new BadRequestException("Missing values for placeholders: " + String.join(", ", missing));
+        }
     }
 
     public List<String> detectPlaceholders(String text) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,16 @@ spring:
         enabled: true
         name: job-tracker-mcp
         version: 1.0.0
+        instructions: >
+          Job Apply Tracker owns the complete resume/CV workflow for job applications.
+          Every job-related resume request MUST be routed through this server's resume tools
+          (Generate-Application-Resume, or the low-level List-Base-Resumes /
+          Detect-Resume-Placeholders / Generate-Resume / Copy-Resume-To-Application sequence).
+          Never fall back to generic document, filesystem, Python, DOCX, PDF, or non-MCP Google
+          Drive tools to produce or edit a resume, including as a silent fallback when a tool
+          call fails — surface the failure and retry instead. A resume request is complete only
+          once this server returns a Google Doc (documentUrl) and PDF (pdfUrl) linked to the
+          application. See resource://job-apply-tracker/resume-workflow-rules for the full workflow.
         # Claude.ai (and other modern MCP connectors) speak the Streamable HTTP
         # transport: a single endpoint that handles both POST (JSON-RPC) and GET
         # (SSE stream). Requires Spring AI 1.1+. The endpoint defaults to /mcp,

--- a/src/main/resources/db/migration/V32__track_resume_template_and_pdf_on_applications.sql
+++ b/src/main/resources/db/migration/V32__track_resume_template_and_pdf_on_applications.sql
@@ -1,0 +1,4 @@
+ALTER TABLE job_applications
+    ADD COLUMN drive_resume_template_id BINARY(16) NULL AFTER drive_resume_generated_at,
+    ADD COLUMN drive_resume_pdf_file_id VARCHAR(255) NULL AFTER drive_resume_template_id,
+    ADD COLUMN drive_resume_pdf_url VARCHAR(2048) NULL AFTER drive_resume_pdf_file_id;

--- a/src/test/java/com/jobtracker/unit/ResumeGenerationApplicationFlowTest.java
+++ b/src/test/java/com/jobtracker/unit/ResumeGenerationApplicationFlowTest.java
@@ -1,0 +1,244 @@
+package com.jobtracker.unit;
+
+import com.jobtracker.config.GoogleDriveProperties;
+import com.jobtracker.entity.GoogleDriveBaseResume;
+import com.jobtracker.entity.GoogleDriveConnection;
+import com.jobtracker.entity.JobApplication;
+import com.jobtracker.entity.User;
+import com.jobtracker.exception.BadRequestException;
+import com.jobtracker.exception.ResourceNotFoundException;
+import com.jobtracker.repository.ApplicationRepository;
+import com.jobtracker.repository.GoogleDriveBaseResumeRepository;
+import com.jobtracker.repository.GoogleDriveConnectionRepository;
+import com.jobtracker.service.GoogleDriveApiClient;
+import com.jobtracker.service.ResumeGenerationService;
+import com.jobtracker.util.SecurityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeGenerationApplicationFlowTest {
+
+    private static final String TEST_SCOPES = "https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/documents.readonly";
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID BASE_RESUME_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID APPLICATION_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID OTHER_TEMPLATE_ID = UUID.fromString("00000000-0000-0000-0000-000000000004");
+
+    @Mock private GoogleDriveApiClient googleDriveApiClient;
+    @Mock private GoogleDriveConnectionRepository connectionRepository;
+    @Mock private GoogleDriveBaseResumeRepository baseResumeRepository;
+    @Mock private ApplicationRepository applicationRepository;
+    @Mock private SecurityUtils securityUtils;
+
+    private ResumeGenerationService service;
+    private User user;
+    private GoogleDriveConnection connection;
+    private GoogleDriveBaseResume baseResume;
+    private JobApplication application;
+
+    @BeforeEach
+    void setUp() {
+        service = new ResumeGenerationService(
+                googleDriveApiClient,
+                new GoogleDriveProperties("client", "secret", "cb", "frontend", "auth", "token", TEST_SCOPES),
+                connectionRepository,
+                baseResumeRepository,
+                applicationRepository,
+                securityUtils
+        );
+
+        user = new User();
+        user.setId(USER_ID);
+
+        connection = new GoogleDriveConnection();
+        connection.setUser(user);
+        connection.setAccessToken("access-token");
+        connection.setRefreshToken("refresh-token");
+        connection.setAccessTokenExpiresAt(LocalDateTime.now().plusHours(1));
+        connection.setRootFolderId("root-folder-id");
+
+        baseResume = new GoogleDriveBaseResume();
+        baseResume.setId(BASE_RESUME_ID);
+        baseResume.setConnection(connection);
+        baseResume.setGoogleFileId("base-doc-id");
+        baseResume.setDocumentName("Base Resume");
+        baseResume.setLanguage("PT");
+        baseResume.setTemplate(true);
+        baseResume.setReadOnly(false);
+
+        application = new JobApplication();
+        application.setId(APPLICATION_ID);
+        application.setUser(user);
+        application.setVacancyName("Backend Engineer");
+        application.setOrganization("Acme");
+        application.setApplicationDate(LocalDate.now());
+        application.setDriveVacancyFolderId("vacancy-folder-id");
+    }
+
+    private void mockFullGenerationFlow() {
+        when(connectionRepository.findByUserId(USER_ID)).thenReturn(Optional.of(connection));
+        when(googleDriveApiClient.getFileMetadata("access-token", "root-folder-id"))
+                .thenReturn(new GoogleDriveApiClient.DriveFileMetadata(
+                        "root-folder-id", "Root", GoogleDriveApiClient.GOOGLE_FOLDER_MIME_TYPE,
+                        "https://drive.google.com/drive/folders/root-folder-id"));
+        when(googleDriveApiClient.getFileMetadata("access-token", "vacancy-folder-id"))
+                .thenReturn(new GoogleDriveApiClient.DriveFileMetadata(
+                        "vacancy-folder-id", "Vacancy", GoogleDriveApiClient.GOOGLE_FOLDER_MIME_TYPE,
+                        "https://drive.google.com/drive/folders/vacancy-folder-id"));
+
+        AtomicInteger callCount = new AtomicInteger();
+        when(googleDriveApiClient.copyGoogleDoc(eq("access-token"), eq("base-doc-id"), eq("vacancy-folder-id"), any()))
+                .thenAnswer(invocation -> new GoogleDriveApiClient.DriveFileMetadata(
+                        "copied-doc-id-" + callCount.incrementAndGet(), "Copied Resume",
+                        GoogleDriveApiClient.GOOGLE_DOC_MIME_TYPE,
+                        "https://docs.google.com/document/d/copied-doc-id/edit"));
+        when(googleDriveApiClient.readGoogleDocText(eq("access-token"), anyString()))
+                .thenReturn("Resumo: {{RESUMO}}");
+        when(googleDriveApiClient.exportGoogleDocAsPdf(eq("access-token"), anyString(), eq("vacancy-folder-id"), any()))
+                .thenReturn(new GoogleDriveApiClient.DriveFileMetadata(
+                        "pdf-id", "Resume.pdf", "application/pdf",
+                        "https://drive.google.com/file/d/pdf-id/view"));
+    }
+
+    @Test
+    void generateApplicationResume_success_withExplicitBaseResumeId() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findByIdAndConnectionUserId(BASE_RESUME_ID, USER_ID)).thenReturn(Optional.of(baseResume));
+        mockFullGenerationFlow();
+
+        var response = service.generateApplicationResume(
+                APPLICATION_ID, BASE_RESUME_ID, null, Map.of("RESUMO", "Senior Java Engineer"));
+
+        assertThat(response.workflowCompleted()).isTrue();
+        assertThat(response.documentUrl()).isNotBlank();
+        assertThat(response.pdfUrl()).isNotBlank();
+        assertThat(response.baseResumeId()).isEqualTo(BASE_RESUME_ID);
+        assertThat(application.getDriveResumeTemplateId()).isEqualTo(BASE_RESUME_ID);
+        assertThat(application.getDriveResumePdfUrl()).isEqualTo(response.pdfUrl());
+    }
+
+    @Test
+    void generateApplicationResume_success_withLanguageAutoSelection() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findAllByConnectionUserIdOrderByCreatedAtAsc(USER_ID)).thenReturn(List.of(baseResume));
+        when(baseResumeRepository.findByIdAndConnectionUserId(BASE_RESUME_ID, USER_ID)).thenReturn(Optional.of(baseResume));
+        mockFullGenerationFlow();
+
+        var response = service.generateApplicationResume(
+                APPLICATION_ID, null, "pt", Map.of("RESUMO", "Senior Java Engineer"));
+
+        assertThat(response.workflowCompleted()).isTrue();
+        assertThat(response.baseResumeId()).isEqualTo(BASE_RESUME_ID);
+    }
+
+    @Test
+    void generateApplicationResume_missingApplication_throwsNotFound() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generateApplicationResume(APPLICATION_ID, BASE_RESUME_ID, null, Map.of("RESUMO", "x")))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verifyNoInteractions(googleDriveApiClient);
+    }
+
+    @Test
+    void generateApplicationResume_missingPlaceholderValues_throwsBadRequest() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findByIdAndConnectionUserId(BASE_RESUME_ID, USER_ID)).thenReturn(Optional.of(baseResume));
+        when(connectionRepository.findByUserId(USER_ID)).thenReturn(Optional.of(connection));
+        when(googleDriveApiClient.readGoogleDocText("access-token", "base-doc-id")).thenReturn("Resumo: {{RESUMO}}");
+
+        assertThatThrownBy(() -> service.generateApplicationResume(APPLICATION_ID, BASE_RESUME_ID, null, Map.of()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("RESUMO");
+
+        verify(googleDriveApiClient, never()).copyGoogleDoc(anyString(), anyString(), anyString(), anyString());
+        verify(applicationRepository, never()).save(any());
+    }
+
+    @Test
+    void generateApplicationResume_readOnlyTemplate_throwsBadRequest() {
+        baseResume.setReadOnly(true);
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findByIdAndConnectionUserId(BASE_RESUME_ID, USER_ID)).thenReturn(Optional.of(baseResume));
+        when(connectionRepository.findByUserId(USER_ID)).thenReturn(Optional.of(connection));
+
+        assertThatThrownBy(() -> service.generateApplicationResume(APPLICATION_ID, BASE_RESUME_ID, null, Map.of("RESUMO", "x")))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("read-only");
+    }
+
+    @Test
+    void generateApplicationResume_ambiguousLanguage_throwsBadRequest() {
+        GoogleDriveBaseResume secondTemplate = new GoogleDriveBaseResume();
+        secondTemplate.setId(OTHER_TEMPLATE_ID);
+        secondTemplate.setConnection(connection);
+        secondTemplate.setGoogleFileId("other-doc-id");
+        secondTemplate.setDocumentName("Other Base Resume");
+        secondTemplate.setLanguage("PT");
+        secondTemplate.setTemplate(true);
+        secondTemplate.setReadOnly(false);
+
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findAllByConnectionUserIdOrderByCreatedAtAsc(USER_ID))
+                .thenReturn(List.of(baseResume, secondTemplate));
+
+        assertThatThrownBy(() -> service.generateApplicationResume(APPLICATION_ID, null, "PT", Map.of("RESUMO", "x")))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Multiple templates");
+    }
+
+    @Test
+    void generateApplicationResume_noTemplateForLanguage_throwsBadRequest() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findAllByConnectionUserIdOrderByCreatedAtAsc(USER_ID)).thenReturn(List.of(baseResume));
+
+        assertThatThrownBy(() -> service.generateApplicationResume(APPLICATION_ID, null, "EN", Map.of("RESUMO", "x")))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("No reusable template");
+    }
+
+    @Test
+    void generateApplicationResume_repeatedCalls_regenerateAndReplaceLinkedResume() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_ID);
+        when(applicationRepository.findByIdAndUserId(APPLICATION_ID, USER_ID)).thenReturn(Optional.of(application));
+        when(baseResumeRepository.findByIdAndConnectionUserId(BASE_RESUME_ID, USER_ID)).thenReturn(Optional.of(baseResume));
+        mockFullGenerationFlow();
+
+        var first = service.generateApplicationResume(APPLICATION_ID, BASE_RESUME_ID, null, Map.of("RESUMO", "First"));
+        var second = service.generateApplicationResume(APPLICATION_ID, BASE_RESUME_ID, null, Map.of("RESUMO", "Second"));
+
+        assertThat(first.copiedFileId()).isNotEqualTo(second.copiedFileId());
+        assertThat(application.getDriveResumeFileId()).isEqualTo(second.copiedFileId());
+        assertThat(application.getDriveResumeDocumentUrl()).isEqualTo(second.documentUrl());
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a new `Generate-Application-Resume` MCP tool that provides an atomic, agent-proof entry point for the complete resume generation workflow. This prevents agents from silently skipping steps or falling back to local file generation by consolidating template selection, placeholder validation, document copying, and PDF export into a single call.

## Key Changes

- **New MCP Tool**: `Generate-Application-Resume` (`McpGoogleDriveTools.java`)
  - Accepts `applicationId`, optional `baseResumeId` or `language` for template selection, and placeholder values
  - Automatically selects the template by language if `baseResumeId` is omitted (fails with clear error if zero or multiple matches)
  - Validates all detected placeholders have values before proceeding
  - Returns `documentUrl`, `pdfUrl`, `baseResumeId`, and `workflowCompleted: true` on success
  - Regenerates the resume on repeated calls, replacing the linked documents while keeping previous files in Drive

- **Service Layer**: `ResumeGenerationService.generateApplicationResume()`
  - Implements template selection by language with disambiguation logic
  - Validates all placeholders are provided before generation
  - Delegates to existing `generateTemplateResume()` for the actual workflow

- **Database Schema**: New columns on `job_applications` table
  - `drive_resume_template_id`: Tracks which base resume template was used
  - `drive_resume_pdf_file_id`: Stores the PDF file ID
  - `drive_resume_pdf_url`: Stores the PDF URL for direct access

- **Entity Updates**: `JobApplication` entity getters/setters for new PDF and template tracking fields

- **Response DTO**: `ResumePlaceholderResponse` now includes `workflowCompleted` boolean flag

- **Documentation & Guardrails**:
  - Enhanced MCP tool descriptions to emphasize this is the mandatory entry point
  - Updated `McpResumeWorkflowRulesResource` with explicit routing rules prohibiting fallback to local file generation
  - Added server-level instructions in `application.yml` reinforcing the workflow requirement
  - Comprehensive test suite (`ResumeGenerationApplicationFlowTest`) covering success paths, error cases, and repeated calls

## Implementation Details

- Template selection by language filters for templates that are marked as `isTemplate()` and not `isReadOnly()`
- Missing placeholder validation provides clear error messages listing all missing keys
- The atomic design ensures agents cannot partially complete the workflow or substitute local generation
- Repeated calls for the same application create new documents and update the application's linked references

https://claude.ai/code/session_01UsJGjEd5HiW97LXeq19YuP