### PR TITLE
Enforce mandatory vacancy registration for all application-related actions

### DIFF
--- a/src/main/java/com/jobtracker/mcp/McpPromptsConfig.java
+++ b/src/main/java/com/jobtracker/mcp/McpPromptsConfig.java
@@ -45,17 +45,29 @@ public class McpPromptsConfig {
                 %s
                 === END VACANCY ===
 
+                MANDATORY REGISTRATION WORKFLOW (applies to this and every other application-related
+                request — generating/adapting a resume, drafting an email/WhatsApp/LinkedIn message,
+                contacting a recruiter, evaluating job fit, or preparing application materials):
+                List-Statuses → Search by exact vacancy URL → Create-Application when absent → Continue requested workflow
+
                 Follow this order exactly:
 
                 STEP 1 - Analyze the vacancy
                 Extract: vacancyName (title), organization (company), vacancyLink (URL if present),
                 required stack, seniority, vacancy language, recruiter name/email if present.
-               
-                STEP 2 - Check for existing application
-                Call List-Applications with the extracted vacancyName, organization, recruiter name/email to check for an existing application.
-                If an application with the same vacancyName and organization exists,
-                return a message indicating that an application already exists and provide its UUID. Do not proceed with the workflow if a duplicate application is
-                found. If no duplicate application exists, proceed to the next step.
+
+                STEP 2 - Check for existing application (mandatory, do not skip)
+                Call List-Statuses to get the valid status values. Then call List-Applications/Search-Applications
+                and search for an existing application using the exact vacancy URL (vacancyLink).
+                Similar vacancy names, recruiters, organizations, salaries, or technology stacks are NOT sufficient
+                evidence of a duplicate. Treat the vacancy as a duplicate only when the vacancyLink is identical to
+                an existing application, or when I explicitly confirm it is the same vacancy.
+                If an exact-URL duplicate exists, return a message indicating that an application already exists
+                and provide its UUID. Do not proceed with the workflow if a duplicate application is found.
+                If the exact URL is not registered (including reposts of an otherwise similar vacancy under a new
+                URL), you MUST call Create-Application before performing the requested resume, message,
+                evaluation, or outreach action — never silently skip vacancy registration. This applies whether
+                the requested action is generating a resume, message, evaluation, or outreach.
 
                 STEP 3 - Read my BASE INFORMATION (TOP PRIORITY, mandatory before generating any content)
                 - Call List-Base-Information and read EVERY document via Get-Base-Information-Content

--- a/src/main/java/com/jobtracker/mcp/resources/McpApplicationCreationRulesResource.java
+++ b/src/main/java/com/jobtracker/mcp/resources/McpApplicationCreationRulesResource.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class McpApplicationCreationRulesResource {
 
-    private static final String LAST_MODIFIED = "2026-06-04";
+    private static final String LAST_MODIFIED = "2026-07-15";
 
     @McpResource(
             uri = McpResourcesConfig.URI_APPLICATION_CREATION_RULES,
@@ -27,6 +27,26 @@ public class McpApplicationCreationRulesResource {
     public String applicationCreationRules(McpSyncServerExchange exchange) {
         return """
                 # Application Creation Rules
+
+                MANDATORY REGISTRATION RULE: creation is mandatory for all application-related actions —
+                generating or adapting a resume, drafting an email/WhatsApp/LinkedIn message, contacting a
+                recruiter, evaluating compatibility with a vacancy, or preparing any application materials.
+                Whenever the user provides a vacancy and shows application intent, register it before
+                performing the requested action. Never silently skip vacancy registration.
+
+                Duplicate detection must prioritize the exact vacancy URL: search existing applications by
+                the exact vacancy URL first. Similar vacancy names, recruiters, organizations, salaries, or
+                technology stacks are not sufficient evidence of a duplicate — treat the vacancy as a
+                duplicate only when the URL is identical or the user explicitly confirms it is the same
+                vacancy. Reposts or new vacancy URLs must be registered as separate applications, even when
+                title, recruiter, salary, and stack are identical to an existing application.
+
+                Registration must happen before resume or outreach generation: call Create-Application (after
+                List-Statuses) first, then perform the requested resume, message, evaluation, or outreach
+                action only once the application exists.
+
+                Always confirm to the user, explicitly, that the vacancy was registered (or that it was
+                already registered under the same URL) before or alongside delivering the requested output.
 
                 Apply these defaults on every Create-Application or Update-Application call:
 

--- a/src/main/java/com/jobtracker/mcp/tools/McpApplicationTools.java
+++ b/src/main/java/com/jobtracker/mcp/tools/McpApplicationTools.java
@@ -135,7 +135,9 @@ public class McpApplicationTools {
     @McpTool(
             name = "Create-Application",
             title = "Create Application",
-            description = "Create a new job application record. IMPORTANT: Call List-Statuses first to get valid status values. Never use a status value from memory.",
+            description = "Create a new job application record. IMPORTANT: Call List-Statuses first to get valid status values. Never use a status value from memory. "
+                    + "This tool must be called automatically whenever the user provides a vacancy in the context of applying, generating a resume, "
+                    + "contacting a recruiter, evaluating job fit, or preparing application materials, unless the exact vacancy URL is already registered.",
             annotations = @McpAnnotations(
                     title = "Create Application",
                     readOnlyHint = false,

--- a/src/test/java/com/jobtracker/unit/mcp/McpApplicationCreationRulesResourceTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpApplicationCreationRulesResourceTest.java
@@ -1,0 +1,24 @@
+package com.jobtracker.unit.mcp;
+
+import com.jobtracker.mcp.resources.McpApplicationCreationRulesResource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpApplicationCreationRulesResourceTest {
+
+    private final McpApplicationCreationRulesResource resource = new McpApplicationCreationRulesResource();
+
+    @Test
+    void applicationCreationRules_mandatesRegistrationForEveryApplicationRelatedAction() {
+        String text = resource.applicationCreationRules(null);
+
+        assertThat(text)
+                .contains("mandatory for all application-related actions")
+                .contains("exact vacancy URL")
+                .contains("are not sufficient evidence of a duplicate")
+                .contains("Reposts or new vacancy URLs must be registered as separate applications")
+                .contains("before resume or outreach generation")
+                .contains("confirm");
+    }
+}

--- a/src/test/java/com/jobtracker/unit/mcp/McpApplicationToolsTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpApplicationToolsTest.java
@@ -15,7 +15,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springaicommunity.mcp.annotation.McpTool;
 
+import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -107,6 +109,25 @@ class McpApplicationToolsTest {
         List<ApplicationResponse> result = tools.getOverdueApplications(null);
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void createApplicationTool_descriptionMandatesAutomaticRegistration() {
+        Method method = java.util.Arrays.stream(McpApplicationTools.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals("createApplication"))
+                .findFirst()
+                .orElseThrow();
+
+        String description = method.getAnnotation(McpTool.class).description();
+
+        assertThat(description)
+                .contains("must be called automatically")
+                .contains("applying")
+                .contains("generating a resume")
+                .contains("contacting a recruiter")
+                .contains("evaluating job fit")
+                .contains("preparing application materials")
+                .contains("unless the exact vacancy URL is already registered");
     }
 
     @Test

--- a/src/test/java/com/jobtracker/unit/mcp/McpPromptsConfigTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpPromptsConfigTest.java
@@ -1,6 +1,8 @@
 package com.jobtracker.unit.mcp;
 
 import com.jobtracker.mcp.McpPromptsConfig;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.junit.jupiter.api.Test;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
@@ -11,6 +13,22 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class McpPromptsConfigTest {
+
+    private final McpPromptsConfig prompts = new McpPromptsConfig();
+
+    @Test
+    void intakeVacancyPrompt_enforcesMandatoryUrlBasedRegistrationWorkflow() {
+        GetPromptResult result = prompts.intakeVacancyPrompt("Senior Java Backend - Julia Argueiro - https://example.com/vaga/123");
+
+        String text = ((TextContent) result.messages().get(0).content()).text();
+
+        assertThat(text)
+                .contains("List-Statuses → Search by exact vacancy URL → Create-Application when absent → Continue requested workflow")
+                .contains("Call List-Statuses")
+                .contains("exact vacancy URL")
+                .contains("Similar vacancy names, recruiters, organizations, salaries, or technology stacks are NOT sufficient")
+                .contains("resume, message, evaluation, or outreach");
+    }
 
     @Test
     void everyPromptHasAMatchingCompletionHandler() {


### PR DESCRIPTION
## Summary
This PR strengthens the vacancy registration workflow by making it mandatory for all application-related actions. The changes ensure that users cannot skip vacancy registration when generating resumes, drafting messages, contacting recruiters, or evaluating job fit. Duplicate detection is now strictly URL-based rather than relying on similar metadata.

## Key Changes

- **Updated intake vacancy prompt** (`McpPromptsConfig.java`):
  - Added explicit "MANDATORY REGISTRATION WORKFLOW" section at the top of the prompt
  - Clarified that registration applies to all application-related requests (resume generation, messaging, recruiter contact, job fit evaluation, etc.)
  - Refined STEP 2 to mandate `List-Statuses` call first, then search by exact vacancy URL
  - Emphasized that similar names, recruiters, organizations, salaries, or stacks are NOT sufficient for duplicate detection
  - Made clear that reposts with new URLs must be registered as separate applications
  - Explicitly stated that `Create-Application` must be called before performing requested actions

- **Enhanced application creation rules resource** (`McpApplicationCreationRulesResource.java`):
  - Added comprehensive "MANDATORY REGISTRATION RULE" section explaining when registration is required
  - Clarified URL-based duplicate detection strategy
  - Specified that registration must happen before resume or outreach generation
  - Added requirement to explicitly confirm to the user that the vacancy was registered
  - Updated `LAST_MODIFIED` timestamp to reflect the changes

- **Updated Create-Application tool description** (`McpApplicationTools.java`):
  - Enhanced tool description to mandate automatic invocation for applying, resume generation, recruiter contact, job fit evaluation, and application material preparation
  - Added condition: "unless the exact vacancy URL is already registered"

- **Added comprehensive test coverage**:
  - New test in `McpPromptsConfigTest` verifying the intake vacancy prompt enforces URL-based registration workflow
  - New test in `McpApplicationToolsTest` validating that the Create-Application tool description mandates automatic registration
  - New test class `McpApplicationCreationRulesResourceTest` ensuring the rules resource contains all mandatory registration language

## Notable Implementation Details

- The workflow now follows a strict sequence: `List-Statuses → Search by exact vacancy URL → Create-Application when absent → Continue requested workflow`
- Duplicate detection is now exclusively URL-based, preventing false positives from similar metadata
- The changes apply universally across all application-related actions, not just initial application creation
- User confirmation of registration is now explicitly required before delivering requested output

https://claude.ai/code/session_01JxzrAoaibRz1nH5a6Egi6t