### PR TITLE
Add PATCH endpoint for partial application updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ A production-ready Spring Boot REST API for tracking job applications, built wit
 | GET | `/api/v1/applications` | List all (paginated + filterable) |
 | GET | `/api/v1/applications/{id}` | Get by ID |
 | PUT | `/api/v1/applications/{id}` | Full update |
+| PATCH | `/api/v1/applications/{id}` | Partial update (omitted fields unchanged, incl. `archived`) |
 | PATCH | `/api/v1/applications/{id}/status` | Update status |
+| PATCH | `/api/v1/applications/{id}/archive` | Archive |
 | PATCH | `/api/v1/applications/{id}/reminder` | Toggle reminder |
 | DELETE | `/api/v1/applications/{id}` | Delete |
 | GET | `/api/v1/applications/upcoming` | Upcoming next steps |

--- a/src/main/java/com/jobtracker/controller/ApplicationController.java
+++ b/src/main/java/com/jobtracker/controller/ApplicationController.java
@@ -83,6 +83,25 @@ public class ApplicationController {
     }
 
     @Operation(
+        summary = "Partially update a job application",
+        description = "Updates only the fields present in the request body; omitted fields keep their current value. "
+                + "Setting 'archived' to false restores an archived application without changing its status.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Application updated",
+                content = @Content(schema = @Schema(implementation = ApplicationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "404", description = "Application not found")
+        }
+    )
+    @PreAuthorize("hasRole('USER') or hasAuthority('SCOPE_write:applications')")
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApplicationResponse> patch(
+            @Parameter(description = "Application ID", required = true) @PathVariable UUID id,
+            @Valid @RequestBody ApplicationPatchRequest request) {
+        return ResponseEntity.ok(applicationService.patch(id, request));
+    }
+
+    @Operation(
         summary = "Update application status",
         description = "Partially updates only the status field of an application",
         responses = {

--- a/src/main/java/com/jobtracker/dto/application/ApplicationPatchRequest.java
+++ b/src/main/java/com/jobtracker/dto/application/ApplicationPatchRequest.java
@@ -1,0 +1,234 @@
+package com.jobtracker.dto.application;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Partial update payload for a job application.
+ *
+ * <p>Every field is optional. Only the JSON properties actually present in the request body are
+ * applied; omitted properties leave the stored value untouched. Presence is tracked by the setters,
+ * so an explicit {@code null} is distinguishable from an omitted property and clears the field.
+ *
+ * <p>Fields backed by a non-nullable column ({@code rhAcceptedConnection}, {@code interviewScheduled},
+ * {@code recruiterDmReminderEnabled}, {@code interviewCount} and {@code archived}) cannot be cleared:
+ * an explicit {@code null} for those is ignored and behaves like an omitted property.
+ */
+@Schema(description = "Partial update payload for a job application. Omitted fields keep their current value.")
+public class ApplicationPatchRequest {
+
+    private final Set<String> providedFields = new HashSet<>();
+
+    @Schema(description = "Job title or vacancy name", example = "Backend Engineer")
+    private String vacancyName;
+
+    @Schema(description = "Name of the recruiter", example = "Jane Smith")
+    private String recruiterName;
+
+    @Schema(description = "Organization or company that posted the vacancy", example = "TechCorp")
+    private String organization;
+
+    @Schema(description = "URL link to the vacancy posting", example = "https://example.com/jobs/123")
+    @Pattern(regexp = "^(https?|ftp)://.*", message = "Vacancy link must be a valid URL")
+    private String vacancyLink;
+
+    @Schema(description = "Date the application was submitted (yyyy-MM-dd)", example = "2024-06-01")
+    @PastOrPresent(message = "Application date cannot be in the future")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate applicationDate;
+
+    @Schema(description = "Whether the recruiter accepted a LinkedIn connection", example = "true")
+    private Boolean rhAcceptedConnection;
+
+    @Schema(description = "Whether an interview has been scheduled", example = "false")
+    private Boolean interviewScheduled;
+
+    @Schema(description = "Date/time of the next step (yyyy-MM-dd'T'HH:mm:ss)", example = "2024-06-10T14:00:00")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime nextStepDateTime;
+
+    @Schema(description = "Application status display name. Send null to move the record back to 'To Send Later'.",
+            example = "Rejected")
+    private String status;
+
+    @Schema(description = "Whether a DM reminder to the recruiter is enabled", example = "true")
+    private Boolean recruiterDmReminderEnabled;
+
+    @Schema(description = "Personal notes about this application", example = "Follow up next Monday")
+    private String note;
+
+    @Schema(description = "Platform or job board where the vacancy was found", example = "LinkedIn")
+    private String platform;
+
+    @Schema(description = "Number of interviews held for this application", example = "2")
+    @Min(0)
+    private Integer interviewCount;
+
+    @Schema(description = "Whether the application is archived. false restores it to the active list.",
+            example = "false")
+    private Boolean archived;
+
+    public String getVacancyName() { return vacancyName; }
+
+    @JsonProperty("vacancyName")
+    public void setVacancyName(String vacancyName) {
+        this.vacancyName = vacancyName;
+        providedFields.add("vacancyName");
+    }
+
+    public String getRecruiterName() { return recruiterName; }
+
+    @JsonProperty("recruiterName")
+    public void setRecruiterName(String recruiterName) {
+        this.recruiterName = recruiterName;
+        providedFields.add("recruiterName");
+    }
+
+    public String getOrganization() { return organization; }
+
+    @JsonProperty("organization")
+    public void setOrganization(String organization) {
+        this.organization = organization;
+        providedFields.add("organization");
+    }
+
+    public String getVacancyLink() { return vacancyLink; }
+
+    @JsonProperty("vacancyLink")
+    public void setVacancyLink(String vacancyLink) {
+        this.vacancyLink = vacancyLink;
+        providedFields.add("vacancyLink");
+    }
+
+    public LocalDate getApplicationDate() { return applicationDate; }
+
+    @JsonProperty("applicationDate")
+    public void setApplicationDate(LocalDate applicationDate) {
+        this.applicationDate = applicationDate;
+        providedFields.add("applicationDate");
+    }
+
+    public Boolean getRhAcceptedConnection() { return rhAcceptedConnection; }
+
+    @JsonProperty("rhAcceptedConnection")
+    public void setRhAcceptedConnection(Boolean rhAcceptedConnection) {
+        if (rhAcceptedConnection == null) {
+            return;
+        }
+        this.rhAcceptedConnection = rhAcceptedConnection;
+        providedFields.add("rhAcceptedConnection");
+    }
+
+    public Boolean getInterviewScheduled() { return interviewScheduled; }
+
+    @JsonProperty("interviewScheduled")
+    public void setInterviewScheduled(Boolean interviewScheduled) {
+        if (interviewScheduled == null) {
+            return;
+        }
+        this.interviewScheduled = interviewScheduled;
+        providedFields.add("interviewScheduled");
+    }
+
+    public LocalDateTime getNextStepDateTime() { return nextStepDateTime; }
+
+    @JsonProperty("nextStepDateTime")
+    public void setNextStepDateTime(LocalDateTime nextStepDateTime) {
+        this.nextStepDateTime = nextStepDateTime;
+        providedFields.add("nextStepDateTime");
+    }
+
+    public String getStatus() { return status; }
+
+    @JsonProperty("status")
+    public void setStatus(String status) {
+        this.status = status;
+        providedFields.add("status");
+    }
+
+    public Boolean getRecruiterDmReminderEnabled() { return recruiterDmReminderEnabled; }
+
+    @JsonProperty("recruiterDmReminderEnabled")
+    public void setRecruiterDmReminderEnabled(Boolean recruiterDmReminderEnabled) {
+        if (recruiterDmReminderEnabled == null) {
+            return;
+        }
+        this.recruiterDmReminderEnabled = recruiterDmReminderEnabled;
+        providedFields.add("recruiterDmReminderEnabled");
+    }
+
+    public String getNote() { return note; }
+
+    @JsonProperty("note")
+    public void setNote(String note) {
+        this.note = note;
+        providedFields.add("note");
+    }
+
+    public String getPlatform() { return platform; }
+
+    @JsonProperty("platform")
+    public void setPlatform(String platform) {
+        this.platform = platform;
+        providedFields.add("platform");
+    }
+
+    public Integer getInterviewCount() { return interviewCount; }
+
+    @JsonProperty("interviewCount")
+    public void setInterviewCount(Integer interviewCount) {
+        if (interviewCount == null) {
+            return;
+        }
+        this.interviewCount = interviewCount;
+        providedFields.add("interviewCount");
+    }
+
+    public Boolean getArchived() { return archived; }
+
+    @JsonProperty("archived")
+    public void setArchived(Boolean archived) {
+        if (archived == null) {
+            return;
+        }
+        this.archived = archived;
+        providedFields.add("archived");
+    }
+
+    public boolean hasVacancyName() { return providedFields.contains("vacancyName"); }
+
+    public boolean hasRecruiterName() { return providedFields.contains("recruiterName"); }
+
+    public boolean hasOrganization() { return providedFields.contains("organization"); }
+
+    public boolean hasVacancyLink() { return providedFields.contains("vacancyLink"); }
+
+    public boolean hasApplicationDate() { return providedFields.contains("applicationDate"); }
+
+    public boolean hasRhAcceptedConnection() { return providedFields.contains("rhAcceptedConnection"); }
+
+    public boolean hasInterviewScheduled() { return providedFields.contains("interviewScheduled"); }
+
+    public boolean hasNextStepDateTime() { return providedFields.contains("nextStepDateTime"); }
+
+    public boolean hasStatus() { return providedFields.contains("status"); }
+
+    public boolean hasRecruiterDmReminderEnabled() { return providedFields.contains("recruiterDmReminderEnabled"); }
+
+    public boolean hasNote() { return providedFields.contains("note"); }
+
+    public boolean hasPlatform() { return providedFields.contains("platform"); }
+
+    public boolean hasInterviewCount() { return providedFields.contains("interviewCount"); }
+
+    public boolean hasArchived() { return providedFields.contains("archived"); }
+}

--- a/src/main/java/com/jobtracker/mcp/resources/McpApplicationLifecycleRulesResource.java
+++ b/src/main/java/com/jobtracker/mcp/resources/McpApplicationLifecycleRulesResource.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class McpApplicationLifecycleRulesResource {
 
-    private static final String LAST_MODIFIED = "2026-07-28";
+    private static final String LAST_MODIFIED = "2026-08-13";
 
     @McpResource(
             uri = McpResourcesConfig.URI_APPLICATION_LIFECYCLE_RULES,
@@ -66,7 +66,10 @@ public class McpApplicationLifecycleRulesResource {
                 - Never call `Archive-Application` after setting `Rejected` or `Approved` unless the user explicitly requested archival.
                 - When archival intent is ambiguous, do not archive. Ask for clarification when clarification is necessary.
                 - Always apply the least destructive mutation necessary to fulfill the request.
-                - Use `Restore-Application` to make an archived record active again. Restoration preserves the current status and all other data.
+                - Use `Restore-Application`, or `Patch-Application` with `archived = false`, to make an archived record active again.
+                  Restoration preserves the current status and all other data.
+                - Use `Patch-Application` for any partial change. It updates only the fields you send, so never resend unrelated
+                  fields or boolean flags to satisfy a schema.
                 - Permanent deletion is allowed only when the user explicitly requests permanent deletion.
                 - Do not delete and recreate an application to change its archive state without explicit user approval.
 
@@ -85,7 +88,10 @@ public class McpApplicationLifecycleRulesResource {
                 Action: set status to `Rejected`. Keep the record visible and non-archived.
 
                 User: `Arquivei por engano, restaure.`
-                Action: call `Restore-Application`. Preserve the current status.
+                Action: call `Restore-Application`, or `Patch-Application` with `archived = false`. Preserve the current status.
+
+                User: `Essa vaga rejeitada deveria estar na lista normal.`
+                Action: call `Patch-Application` with `archived = false` only. Do not change the status.
                 """;
     }
 }

--- a/src/main/java/com/jobtracker/mcp/tools/McpApplicationTools.java
+++ b/src/main/java/com/jobtracker/mcp/tools/McpApplicationTools.java
@@ -2,6 +2,7 @@ package com.jobtracker.mcp.tools;
 
 import com.jobtracker.dto.application.ApplicationFilter;
 import com.jobtracker.dto.application.ApplicationPageResponse;
+import com.jobtracker.dto.application.ApplicationPatchRequest;
 import com.jobtracker.dto.application.ApplicationRequest;
 import com.jobtracker.dto.application.ApplicationResponse;
 import com.jobtracker.dto.application.MarkDmSentRequest;
@@ -210,6 +211,54 @@ public class McpApplicationTools {
                 recruiterDmReminderEnabled != null ? recruiterDmReminderEnabled : Boolean.FALSE,
                 note, platform, null);
         return applicationService.update(UUID.fromString(id), request);
+    }
+
+    @McpTool(
+            name = "Patch-Application",
+            title = "Patch Application",
+            description = "Partially update an existing job application. Only the parameters you send are changed; every omitted field keeps its current value. "
+                    + "Prefer this tool over Update-Application: never resend unrelated fields or boolean flags just to satisfy a schema. "
+                    + "Set archived to false to restore an archived application to the active list, or to true to archive it. "
+                    + "Restoring and archiving preserve the current status, and changing status never archives or restores a record. "
+                    + "IMPORTANT: Call List-Statuses first whenever you send status. Never use a status value from memory.",
+            annotations = @McpAnnotations(
+                    title = "Patch Application",
+                    readOnlyHint = false,
+                    destructiveHint = false,
+                    idempotentHint = true,
+                    openWorldHint = false))
+    @AuditMcpOperation(action = "Patch-Application")
+    public ApplicationResponse patchApplication(
+            McpSyncRequestContext ctx,
+            @McpToolParam(required = true, description = "Application UUID to patch") String id,
+            @McpToolParam(required = false, description = "Job title or vacancy name") String vacancyName,
+            @McpToolParam(required = false, description = "Recruiter name") String recruiterName,
+            @McpToolParam(required = false, description = "Company or organization name") String organization,
+            @McpToolParam(required = false, description = "URL to the vacancy posting") String vacancyLink,
+            @McpToolParam(required = false, description = "Date applied yyyy-MM-dd") String applicationDate,
+            @McpToolParam(required = false, description = "Whether the recruiter accepted a LinkedIn connection") Boolean rhAcceptedConnection,
+            @McpToolParam(required = false, description = "Whether an interview has been scheduled") Boolean interviewScheduled,
+            @McpToolParam(required = false, description = "Next follow-up date/time yyyy-MM-ddTHH:mm:ss") String nextStepDateTime,
+            @McpToolParam(required = false, description = "Status display name from List-Statuses") String status,
+            @McpToolParam(required = false, description = "Whether a DM reminder to the recruiter is enabled") Boolean recruiterDmReminderEnabled,
+            @McpToolParam(required = false, description = "Personal notes about this application") String note,
+            @McpToolParam(required = false, description = "Platform or job board where the vacancy was found, e.g. LinkedIn, Gupy, Indeed, Catho") String platform,
+            @McpToolParam(required = false, description = "true to archive the application, false to restore it to the active list. Independent of status.") Boolean archived) {
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        if (vacancyName != null) request.setVacancyName(vacancyName);
+        if (recruiterName != null) request.setRecruiterName(recruiterName);
+        if (organization != null) request.setOrganization(organization);
+        if (vacancyLink != null) request.setVacancyLink(vacancyLink);
+        if (applicationDate != null) request.setApplicationDate(LocalDate.parse(applicationDate));
+        if (rhAcceptedConnection != null) request.setRhAcceptedConnection(rhAcceptedConnection);
+        if (interviewScheduled != null) request.setInterviewScheduled(interviewScheduled);
+        if (nextStepDateTime != null) request.setNextStepDateTime(LocalDateTime.parse(nextStepDateTime));
+        if (status != null) request.setStatus(status);
+        if (recruiterDmReminderEnabled != null) request.setRecruiterDmReminderEnabled(recruiterDmReminderEnabled);
+        if (note != null) request.setNote(note);
+        if (platform != null) request.setPlatform(platform);
+        if (archived != null) request.setArchived(archived);
+        return applicationService.patch(UUID.fromString(id), request);
     }
 
     @McpTool(

--- a/src/main/java/com/jobtracker/service/ApplicationService.java
+++ b/src/main/java/com/jobtracker/service/ApplicationService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -112,6 +113,21 @@ public class ApplicationService {
         boolean previousInterviewScheduled = app.isInterviewScheduled();
         String previousNote = app.getNote();
         mapRequestToEntity(request, app);
+        JobApplication saved = applicationRepository.save(app);
+        interviewMetricsService.recordStatusTransition(saved, previousStatus, saved.getStatus());
+        gamificationService.onApplicationUpdated(saved, previousStatus, previousInterviewScheduled, previousNote);
+        return applicationMapper.toResponse(saved);
+    }
+
+    @Transactional
+    public ApplicationResponse patch(UUID id, ApplicationPatchRequest request) {
+        UUID userId = securityUtils.getCurrentUserId();
+        JobApplication app = applicationRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found with id: " + id));
+        String previousStatus = app.getStatus();
+        boolean previousInterviewScheduled = app.isInterviewScheduled();
+        String previousNote = app.getNote();
+        applyPatchToEntity(request, app);
         JobApplication saved = applicationRepository.save(app);
         interviewMetricsService.recordStatusTransition(saved, previousStatus, saved.getStatus());
         gamificationService.onApplicationUpdated(saved, previousStatus, previousInterviewScheduled, previousNote);
@@ -246,6 +262,86 @@ public class ApplicationService {
         app.setPlatform(request.platform());
         if (request.interviewCount() != null) {
             app.setInterviewCount(request.interviewCount());
+        }
+    }
+
+    private void applyPatchToEntity(ApplicationPatchRequest request, JobApplication app) {
+        if (request.hasVacancyName()) {
+            app.setVacancyName(normalizeOptionalText(request.getVacancyName()));
+        }
+        if (request.hasRecruiterName()) {
+            app.setRecruiterName(request.getRecruiterName());
+        }
+        if (request.hasOrganization()) {
+            app.setOrganization(request.getOrganization());
+        }
+        if (request.hasVacancyLink()) {
+            app.setVacancyLink(request.getVacancyLink());
+        }
+        if (request.hasRhAcceptedConnection()) {
+            app.setRhAcceptedConnection(request.getRhAcceptedConnection());
+        }
+        if (request.hasInterviewScheduled()) {
+            app.setInterviewScheduled(request.getInterviewScheduled());
+        }
+        if (request.hasNextStepDateTime()) {
+            app.setNextStepDateTime(request.getNextStepDateTime());
+        }
+        if (request.hasRecruiterDmReminderEnabled()) {
+            app.setRecruiterDmReminderEnabled(request.getRecruiterDmReminderEnabled());
+        }
+        if (request.hasNote()) {
+            app.setNote(normalizeOptionalText(request.getNote()));
+        }
+        if (request.hasPlatform()) {
+            app.setPlatform(request.getPlatform());
+        }
+        if (request.hasInterviewCount()) {
+            app.setInterviewCount(request.getInterviewCount());
+        }
+        // Status and application date are reconciled together because the draft ("to send later")
+        // flag derives from both. Leave them untouched when neither is part of the patch.
+        if (request.hasStatus() || request.hasApplicationDate()) {
+            applyStatusAndDatePatch(request, app);
+        }
+        if (request.hasArchived()) {
+            applyArchivedChange(app, request.getArchived());
+        }
+    }
+
+    private void applyStatusAndDatePatch(ApplicationPatchRequest request, JobApplication app) {
+        String status = request.hasStatus() ? request.getStatus() : app.getStatus();
+        LocalDate applicationDate = request.hasApplicationDate()
+                ? request.getApplicationDate() : app.getApplicationDate();
+
+        boolean isSendLater = status == null || status.isBlank()
+                || TO_SEND_LATER_STATUS.equalsIgnoreCase(status);
+        if (!isSendLater && applicationDate == null) {
+            throw new BadRequestException(
+                    "applicationDate is required when status is provided. Set status to null for 'To Send Later'.");
+        }
+
+        if (isSendLater) {
+            // Clears the application date and flags the record as a draft.
+            applyStatusChange(app, null);
+            return;
+        }
+        app.setToSendLater(false);
+        app.setApplicationDate(applicationDate);
+        // Only a status the caller actually sent needs validating; the stored one is already valid.
+        applyStatusChange(app, request.hasStatus() ? validateStatus(status) : status);
+    }
+
+    /** Archiving keeps the timestamp of the first archival so repeated calls are idempotent. */
+    private void applyArchivedChange(JobApplication app, boolean archived) {
+        if (!archived) {
+            app.setArchived(false);
+            app.setArchivedAt(null);
+            return;
+        }
+        if (!app.isArchived()) {
+            app.setArchived(true);
+            app.setArchivedAt(LocalDateTime.now());
         }
     }
 

--- a/src/test/java/com/jobtracker/e2e/McpToolsE2ETest.java
+++ b/src/test/java/com/jobtracker/e2e/McpToolsE2ETest.java
@@ -158,6 +158,31 @@ class McpToolsE2ETest extends AbstractE2ETest {
     }
 
     @Test
+    void toolsList_advertisesPatchApplicationWithOnlyIdRequiredAndAnArchivedFlag() {
+        Response response = given()
+                .header("Authorization", "Bearer " + betaAccessToken)
+                .header(MCP_SESSION_ID_HEADER, mcpSessionId)
+                .accept("application/json, text/event-stream")
+                .contentType("application/json")
+                .body(TOOLS_LIST_BODY)
+                .post(MCP_ENDPOINT)
+                .then().statusCode(200).extract().response();
+
+        JsonPath body = mcpJsonRpcBody(response);
+        assertThat(body.getList("result.tools.name", String.class))
+                .as("Expected 'Patch-Application' in the tools/list response — issue #69")
+                .contains("Patch-Application");
+
+        String schemaPath = "result.tools.find { it.name == 'Patch-Application' }.inputSchema";
+        assertThat(body.getMap(schemaPath + ".properties").keySet())
+                .as("Patch-Application must accept the archived flag so archived records can be restored")
+                .contains("archived", "status", "note");
+        assertThat(body.getList(schemaPath + ".required", String.class))
+                .as("Only the application id may be required; every patchable field stays optional")
+                .containsExactly("id");
+    }
+
+    @Test
     void listBaseInformationTool_authenticatedBetaUser_returnsSuccessfulResult() {
         Response response = given()
                 .header("Authorization", "Bearer " + betaAccessToken)

--- a/src/test/java/com/jobtracker/integration/ApplicationControllerIT.java
+++ b/src/test/java/com/jobtracker/integration/ApplicationControllerIT.java
@@ -253,6 +253,144 @@ class ApplicationControllerIT extends AbstractIntegrationTest {
     }
 
     @Test
+    void patchApplication_shouldRestoreArchivedApplicationAndKeepItsStatus() throws Exception {
+        String id = createApplication("Restore Me");
+
+        mockMvc.perform(patch("/api/v1/applications/{id}/status", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": \"Rejected\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("Rejected"))
+                .andExpect(jsonPath("$.archived").value(false));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(true))
+                .andExpect(jsonPath("$.archivedAt").exists())
+                .andExpect(jsonPath("$.status").value("Rejected"));
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": false}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(false))
+                .andExpect(jsonPath("$.archivedAt").doesNotExist())
+                .andExpect(jsonPath("$.status").value("Rejected"));
+
+        mockMvc.perform(get("/api/v1/applications")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.applications[0].status").value("Rejected"));
+
+        mockMvc.perform(get("/api/v1/applications")
+                        .param("archived", "true")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    void patchApplication_archivingTwice_shouldKeepTheFirstArchivedAt() throws Exception {
+        String id = createApplication("Idempotent Archive");
+
+        MvcResult firstArchive = mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": true}"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String archivedAt = objectMapper.readTree(firstArchive.getResponse().getContentAsString())
+                .get("archivedAt").asText();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(true))
+                .andExpect(jsonPath("$.archivedAt").value(archivedAt));
+    }
+
+    @Test
+    void patchApplication_shouldLeaveOmittedFieldsUnchanged() throws Exception {
+        String id = createApplication("Partial Update");
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"note\": \"Only the note changed\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.note").value("Only the note changed"))
+                .andExpect(jsonPath("$.vacancyName").value("Partial Update"))
+                .andExpect(jsonPath("$.recruiterName").value("Some Recruiter"))
+                .andExpect(jsonPath("$.organization").value("HR Department"))
+                .andExpect(jsonPath("$.status").value("RH"))
+                .andExpect(jsonPath("$.applicationDate").value(LocalDate.now().minusDays(1).toString()));
+    }
+
+    @Test
+    void patchApplication_shouldRejectInvalidStatus() throws Exception {
+        String id = createApplication("Bad Status");
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": \"Not A Real Status\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void patchApplication_shouldReturn404_whenNotFound() throws Exception {
+        mockMvc.perform(patch("/api/v1/applications/{id}", UUID.randomUUID())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": false}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void patchApplication_shouldReturn403_whenNotAuthenticated() throws Exception {
+        String id = createApplication("Unauthenticated Patch");
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": false}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void patchApplication_shouldReturn404_whenApplicationBelongsToAnotherUser() throws Exception {
+        String id = createApplication("Owned By First User");
+
+        RegisterRequest otherUser = new RegisterRequest(
+                "Other User", "otheruser@example.com", "pass1234", "pass1234", true);
+        MvcResult registerResult = mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(otherUser)))
+                .andReturn();
+        String otherToken = objectMapper.readValue(
+                registerResult.getResponse().getContentAsString(), AuthResponse.class).accessToken();
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + otherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"archived\": true}"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.archived").value(false));
+    }
+
+    @Test
     void getAll_shouldReturnPagedResponse() throws Exception {
         mockMvc.perform(post("/api/v1/applications")
                 .header("Authorization", "Bearer " + accessToken)
@@ -376,6 +514,16 @@ class ApplicationControllerIT extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.currentXp").value(expectedXp))
                 .andExpect(jsonPath("$.level").value(expectedLevel));
+    }
+
+    private String createApplication(String vacancyName) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/applications")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(buildRequest(vacancyName))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
     }
 
     private ApplicationRequest buildRequest(String vacancyName) {

--- a/src/test/java/com/jobtracker/unit/ApplicationPatchRequestTest.java
+++ b/src/test/java/com/jobtracker/unit/ApplicationPatchRequestTest.java
@@ -1,0 +1,99 @@
+package com.jobtracker.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.jobtracker.dto.application.ApplicationPatchRequest;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The patch semantics depend on telling an omitted JSON property apart from an explicit null, so the
+ * deserialization behaviour is pinned down here rather than only through the controller.
+ */
+class ApplicationPatchRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    void omittedProperties_areNotMarkedAsProvided() throws Exception {
+        ApplicationPatchRequest request = read("{\"archived\": false}");
+
+        assertThat(request.hasArchived()).isTrue();
+        assertThat(request.getArchived()).isFalse();
+        assertThat(request.hasStatus()).isFalse();
+        assertThat(request.hasNote()).isFalse();
+        assertThat(request.hasVacancyName()).isFalse();
+        assertThat(request.hasApplicationDate()).isFalse();
+    }
+
+    @Test
+    void explicitNull_onNullableField_isProvidedAndClearsTheValue() throws Exception {
+        ApplicationPatchRequest request = read("{\"note\": null}");
+
+        assertThat(request.hasNote()).isTrue();
+        assertThat(request.getNote()).isNull();
+    }
+
+    @Test
+    void explicitNull_onNonNullableField_isIgnored() throws Exception {
+        ApplicationPatchRequest request = read("{\"archived\": null, \"interviewScheduled\": null}");
+
+        assertThat(request.hasArchived()).isFalse();
+        assertThat(request.hasInterviewScheduled()).isFalse();
+    }
+
+    @Test
+    void emptyBody_marksNothingAsProvided() throws Exception {
+        ApplicationPatchRequest request = read("{}");
+
+        assertThat(request.hasArchived()).isFalse();
+        assertThat(request.hasStatus()).isFalse();
+        assertThat(request.hasNote()).isFalse();
+        assertThat(request.hasApplicationDate()).isFalse();
+        assertThat(request.hasInterviewCount()).isFalse();
+    }
+
+    @Test
+    void allSupportedFields_areDeserialized() throws Exception {
+        ApplicationPatchRequest request = read("""
+                {
+                  "vacancyName": "Backend Engineer",
+                  "recruiterName": "Jane Smith",
+                  "organization": "TechCorp",
+                  "vacancyLink": "https://example.com/jobs/123",
+                  "applicationDate": "2024-06-01",
+                  "rhAcceptedConnection": true,
+                  "interviewScheduled": true,
+                  "nextStepDateTime": "2024-06-10T14:00:00",
+                  "status": "Rejected",
+                  "recruiterDmReminderEnabled": true,
+                  "note": "Follow up",
+                  "platform": "LinkedIn",
+                  "interviewCount": 3,
+                  "archived": false
+                }
+                """);
+
+        assertThat(request.getVacancyName()).isEqualTo("Backend Engineer");
+        assertThat(request.getRecruiterName()).isEqualTo("Jane Smith");
+        assertThat(request.getOrganization()).isEqualTo("TechCorp");
+        assertThat(request.getVacancyLink()).isEqualTo("https://example.com/jobs/123");
+        assertThat(request.getApplicationDate()).isEqualTo(LocalDate.of(2024, 6, 1));
+        assertThat(request.getRhAcceptedConnection()).isTrue();
+        assertThat(request.getInterviewScheduled()).isTrue();
+        assertThat(request.getNextStepDateTime()).isEqualTo("2024-06-10T14:00:00");
+        assertThat(request.getStatus()).isEqualTo("Rejected");
+        assertThat(request.getRecruiterDmReminderEnabled()).isTrue();
+        assertThat(request.getNote()).isEqualTo("Follow up");
+        assertThat(request.getPlatform()).isEqualTo("LinkedIn");
+        assertThat(request.getInterviewCount()).isEqualTo(3);
+        assertThat(request.getArchived()).isFalse();
+    }
+
+    private ApplicationPatchRequest read(String json) throws Exception {
+        return objectMapper.readValue(json, ApplicationPatchRequest.class);
+    }
+}

--- a/src/test/java/com/jobtracker/unit/ApplicationServiceTest.java
+++ b/src/test/java/com/jobtracker/unit/ApplicationServiceTest.java
@@ -249,6 +249,204 @@ class ApplicationServiceTest {
     }
 
     @Test
+    void patch_shouldRestoreArchivedApplicationWithoutChangingStatus() {
+        app.setArchived(true);
+        app.setArchivedAt(LocalDateTime.now().minusDays(1));
+        app.setStatus("Rejected");
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setArchived(false);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.isArchived()).isFalse();
+        assertThat(app.getArchivedAt()).isNull();
+        assertThat(app.getStatus()).isEqualTo("Rejected");
+        verify(applicationRepository).save(app);
+    }
+
+    @Test
+    void patch_shouldArchiveAndStampArchivedAt() {
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setArchived(true);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.isArchived()).isTrue();
+        assertThat(app.getArchivedAt()).isNotNull();
+    }
+
+    @Test
+    void patch_archivingAlreadyArchivedApplication_keepsOriginalArchivedAt() {
+        LocalDateTime originalArchivedAt = LocalDateTime.now().minusDays(3);
+        app.setArchived(true);
+        app.setArchivedAt(originalArchivedAt);
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setArchived(true);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.isArchived()).isTrue();
+        assertThat(app.getArchivedAt()).isEqualTo(originalArchivedAt);
+    }
+
+    @Test
+    void patch_restoringActiveApplication_isIdempotent() {
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setArchived(false);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.isArchived()).isFalse();
+        assertThat(app.getArchivedAt()).isNull();
+    }
+
+    @Test
+    void patch_shouldLeaveOmittedFieldsUnchanged() {
+        app.setRecruiterName("Original Recruiter");
+        app.setPlatform("LinkedIn");
+        app.setInterviewScheduled(true);
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setNote("Updated note");
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.getNote()).isEqualTo("Updated note");
+        assertThat(app.getVacancyName()).isEqualTo("Software Engineer");
+        assertThat(app.getRecruiterName()).isEqualTo("Original Recruiter");
+        assertThat(app.getPlatform()).isEqualTo("LinkedIn");
+        assertThat(app.isInterviewScheduled()).isTrue();
+        assertThat(app.getStatus()).isEqualTo("RH");
+        assertThat(app.getApplicationDate()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    void patch_shouldValidateStatusAgainstRepository() {
+        stubPatchLookup();
+        when(applicationStatusRepository.existsByName("Technical Test")).thenReturn(true);
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setStatus("Technical Test");
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.getStatus()).isEqualTo("Technical Test");
+        verify(interviewMetricsService).recordStatusTransition(app, "RH", "Technical Test");
+    }
+
+    @Test
+    void patch_applicationDateOnly_keepsStatusWithoutRevalidatingIt() {
+        LocalDate newDate = LocalDate.now().minusDays(5);
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setApplicationDate(newDate);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.getApplicationDate()).isEqualTo(newDate);
+        assertThat(app.getStatus()).isEqualTo("RH");
+        assertThat(app.isToSendLater()).isFalse();
+        verify(applicationStatusRepository, never()).existsByName(any());
+    }
+
+    @Test
+    void patch_shouldRejectUnknownStatus() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_UUID);
+        when(applicationRepository.findByIdAndUserId(APP_UUID, USER_UUID)).thenReturn(Optional.of(app));
+        when(applicationStatusRepository.existsByName("Nope")).thenReturn(false);
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setStatus("Nope");
+
+        assertThatThrownBy(() -> applicationService.patch(APP_UUID, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Invalid status value");
+    }
+
+    @Test
+    void patch_clearingStatus_movesApplicationBackToDraft() {
+        stubPatchLookup();
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setStatus(null);
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.getStatus()).isNull();
+        assertThat(app.getApplicationDate()).isNull();
+        assertThat(app.isToSendLater()).isTrue();
+    }
+
+    @Test
+    void patch_clearingApplicationDateWhileStatusIsSet_shouldThrow() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_UUID);
+        when(applicationRepository.findByIdAndUserId(APP_UUID, USER_UUID)).thenReturn(Optional.of(app));
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setApplicationDate(null);
+
+        assertThatThrownBy(() -> applicationService.patch(APP_UUID, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("applicationDate is required");
+    }
+
+    @Test
+    void patch_shouldNotArchiveWhenStatusBecomesRejected() {
+        stubPatchLookup();
+        when(applicationStatusRepository.existsByName("Rejected")).thenReturn(true);
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setStatus("Rejected");
+
+        applicationService.patch(APP_UUID, request);
+
+        assertThat(app.getStatus()).isEqualTo("Rejected");
+        assertThat(app.isArchived()).isFalse();
+        assertThat(app.getArchivedAt()).isNull();
+    }
+
+    @Test
+    void patch_emptyPayload_leavesApplicationUntouched() {
+        stubPatchLookup();
+
+        applicationService.patch(APP_UUID, new ApplicationPatchRequest());
+
+        assertThat(app.getStatus()).isEqualTo("RH");
+        assertThat(app.getNote()).isEqualTo("Follow up this week");
+        assertThat(app.isArchived()).isFalse();
+    }
+
+    @Test
+    void patch_shouldThrow_whenApplicationBelongsToAnotherUser() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_UUID);
+        when(applicationRepository.findByIdAndUserId(OTHER_UUID, USER_UUID)).thenReturn(Optional.empty());
+
+        ApplicationPatchRequest request = new ApplicationPatchRequest();
+        request.setArchived(false);
+
+        assertThatThrownBy(() -> applicationService.patch(OTHER_UUID, request))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(applicationRepository, never()).save(any(JobApplication.class));
+    }
+
+    private void stubPatchLookup() {
+        when(securityUtils.getCurrentUserId()).thenReturn(USER_UUID);
+        when(applicationRepository.findByIdAndUserId(APP_UUID, USER_UUID)).thenReturn(Optional.of(app));
+        when(applicationRepository.save(app)).thenReturn(app);
+        when(applicationMapper.toResponse(app)).thenReturn(response);
+    }
+
+    @Test
     void markDmSent_shouldAwardOnlyOnFirstSend() {
         when(securityUtils.getCurrentUserId()).thenReturn(USER_UUID);
         when(applicationRepository.findByIdAndUserId(APP_UUID, USER_UUID)).thenReturn(Optional.of(app));

--- a/src/test/java/com/jobtracker/unit/mcp/McpApplicationLifecycleRulesResourceTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpApplicationLifecycleRulesResourceTest.java
@@ -25,4 +25,14 @@ class McpApplicationLifecycleRulesResourceTest {
                 .contains("permanent deletion")
                 .contains("Do not delete and recreate");
     }
+
+    @Test
+    void applicationLifecycleRules_documentPatchApplicationAsThePartialUpdateTool() {
+        String text = resource.applicationLifecycleRules(null);
+
+        assertThat(text)
+                .contains("Patch-Application")
+                .contains("archived = false")
+                .contains("only the fields you send");
+    }
 }

--- a/src/test/java/com/jobtracker/unit/mcp/McpApplicationToolsTest.java
+++ b/src/test/java/com/jobtracker/unit/mcp/McpApplicationToolsTest.java
@@ -2,6 +2,7 @@ package com.jobtracker.unit.mcp;
 
 import com.jobtracker.dto.application.ApplicationFilter;
 import com.jobtracker.dto.application.ApplicationPageResponse;
+import com.jobtracker.dto.application.ApplicationPatchRequest;
 import com.jobtracker.dto.application.ApplicationRequest;
 import com.jobtracker.dto.application.ApplicationResponse;
 import com.jobtracker.dto.application.MarkDmSentRequest;
@@ -16,8 +17,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -180,6 +183,113 @@ class McpApplicationToolsTest {
     }
 
     @Test
+    void patchApplication_sendsOnlyTheProvidedFields() {
+        UUID id = UUID.randomUUID();
+        ArgumentCaptor<ApplicationPatchRequest> captor = ArgumentCaptor.forClass(ApplicationPatchRequest.class);
+        when(applicationService.patch(eq(id), any())).thenReturn(applicationResponseWithId(id));
+
+        tools.patchApplication(null, id.toString(), null, null, null, null, null, null, null,
+                null, null, null, null, null, Boolean.FALSE);
+
+        verify(applicationService).patch(eq(id), captor.capture());
+        ApplicationPatchRequest request = captor.getValue();
+        assertThat(request.hasArchived()).isTrue();
+        assertThat(request.getArchived()).isFalse();
+        assertThat(request.hasStatus()).isFalse();
+        assertThat(request.hasVacancyName()).isFalse();
+        assertThat(request.hasRhAcceptedConnection()).isFalse();
+        assertThat(request.hasInterviewScheduled()).isFalse();
+        assertThat(request.hasRecruiterDmReminderEnabled()).isFalse();
+    }
+
+    @Test
+    void patchApplication_mapsAllParams() {
+        UUID id = UUID.randomUUID();
+        ArgumentCaptor<ApplicationPatchRequest> captor = ArgumentCaptor.forClass(ApplicationPatchRequest.class);
+        when(applicationService.patch(eq(id), any())).thenReturn(applicationResponseWithId(id));
+
+        tools.patchApplication(
+                null,
+                id.toString(),
+                "Backend Engineer",
+                "Jane Smith",
+                "TechCorp",
+                "https://example.com/job",
+                "2025-06-01",
+                Boolean.TRUE,
+                Boolean.FALSE,
+                "2025-06-10T14:00:00",
+                "RH",
+                Boolean.TRUE,
+                "Follow up Monday",
+                "LinkedIn",
+                Boolean.TRUE);
+
+        verify(applicationService).patch(eq(id), captor.capture());
+        ApplicationPatchRequest request = captor.getValue();
+        assertThat(request.getVacancyName()).isEqualTo("Backend Engineer");
+        assertThat(request.getRecruiterName()).isEqualTo("Jane Smith");
+        assertThat(request.getOrganization()).isEqualTo("TechCorp");
+        assertThat(request.getVacancyLink()).isEqualTo("https://example.com/job");
+        assertThat(request.getApplicationDate()).isEqualTo(LocalDate.of(2025, 6, 1));
+        assertThat(request.getRhAcceptedConnection()).isTrue();
+        assertThat(request.getInterviewScheduled()).isFalse();
+        assertThat(request.getNextStepDateTime()).isEqualTo(LocalDateTime.of(2025, 6, 10, 14, 0, 0));
+        assertThat(request.getStatus()).isEqualTo("RH");
+        assertThat(request.getRecruiterDmReminderEnabled()).isTrue();
+        assertThat(request.getNote()).isEqualTo("Follow up Monday");
+        assertThat(request.getPlatform()).isEqualTo("LinkedIn");
+        assertThat(request.getArchived()).isTrue();
+    }
+
+    @Test
+    void patchApplication_returnsUpdatedApplication() {
+        UUID id = UUID.randomUUID();
+        ApplicationResponse expected = applicationResponseWithId(id);
+        when(applicationService.patch(eq(id), any())).thenReturn(expected);
+
+        ApplicationResponse result = tools.patchApplication(null, id.toString(), null, null, null, null,
+                null, null, null, null, null, null, null, null, Boolean.FALSE);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void patchApplicationTool_isExposedWithPartialUpdateAndArchiveSemantics() {
+        Method method = toolMethod("patchApplication");
+
+        assertThat(method.getAnnotation(McpTool.class).name()).isEqualTo("Patch-Application");
+        assertThat(method.getAnnotation(McpTool.class).description())
+                .containsIgnoringCase("partially update")
+                .contains("omitted field")
+                .contains("archived")
+                .containsIgnoringCase("restore")
+                .contains("List-Statuses")
+                .contains("never archives or restores");
+    }
+
+    @Test
+    void patchApplicationTool_schemaMarksOnlyIdAsRequired() {
+        Method method = toolMethod("patchApplication");
+        Parameter[] parameters = method.getParameters();
+
+        // parameters[0] is the framework-injected McpSyncRequestContext, which carries no @McpToolParam.
+        assertThat(parameters[1].getAnnotation(McpToolParam.class).required()).isTrue();
+        assertThat(java.util.Arrays.stream(parameters)
+                .map(p -> p.getAnnotation(McpToolParam.class))
+                .filter(java.util.Objects::nonNull)
+                .filter(McpToolParam::required)
+                .count()).isEqualTo(1);
+
+        Parameter archived = parameters[parameters.length - 1];
+        assertThat(archived.getType()).isEqualTo(Boolean.class);
+        assertThat(archived.getAnnotation(McpToolParam.class).required()).isFalse();
+        assertThat(archived.getAnnotation(McpToolParam.class).description())
+                .contains("archive")
+                .contains("restore");
+    }
+
+    @Test
     void updateApplicationStatus_buildsCorrectRequest() {
         UUID id = UUID.randomUUID();
         ApplicationResponse expected = applicationResponseWithId(id);
@@ -271,11 +381,14 @@ class McpApplicationToolsTest {
     }
 
     private static String toolDescription(String javaMethodName) {
-        Method method = java.util.Arrays.stream(McpApplicationTools.class.getDeclaredMethods())
+        return toolMethod(javaMethodName).getAnnotation(McpTool.class).description();
+    }
+
+    private static Method toolMethod(String javaMethodName) {
+        return java.util.Arrays.stream(McpApplicationTools.class.getDeclaredMethods())
                 .filter(candidate -> candidate.getName().equals(javaMethodName))
                 .findFirst()
                 .orElseThrow();
-        return method.getAnnotation(McpTool.class).description();
     }
 
     private static ApplicationResponse applicationResponseWithId(UUID id) {


### PR DESCRIPTION
## Summary
Implements a new PATCH endpoint (`PATCH /api/v1/applications/{id}`) that enables partial updates to job applications. This complements the existing PUT endpoint by allowing clients to update only specific fields without resending the entire application object.

## Key Changes

- **New DTO: `ApplicationPatchRequest`** — A specialized request class that tracks which fields were actually provided in the JSON payload, distinguishing between omitted properties (left unchanged) and explicit `null` values (cleared). Non-nullable fields (`archived`, `interviewScheduled`, `recruiterDmReminderEnabled`, `interviewCount`) ignore explicit nulls.

- **Service Layer: `ApplicationService.patch()`** — Implements the core patch logic:
  - Applies only provided fields to the entity
  - Validates status values against the repository when status is being changed
  - Handles status and application date reconciliation (moving to/from draft state)
  - Manages archive/restore semantics: archiving sets `archivedAt` timestamp; restoring clears it while preserving the application's status
  - Records status transitions and gamification events

- **Controller Endpoint** — New `PATCH /api/v1/applications/{id}` endpoint with OpenAPI documentation and proper error handling (400 for validation, 404 for not found, 403 for unauthorized).

- **MCP Tool: `Patch-Application`** — Exposes the patch functionality to Claude/AI clients with clear semantics: only required parameter is the application ID; all other fields are optional. Includes guidance to call `List-Statuses` before sending a status value.

- **Comprehensive Test Coverage**:
  - Unit tests for patch semantics (omitted vs. null, archive/restore idempotency, status validation)
  - Integration tests covering restore workflows, archive timestamp preservation, permission checks
  - MCP tool tests verifying parameter mapping and schema correctness
  - Deserialization tests pinning down JSON parsing behavior

## Notable Implementation Details

- **Partial Update Semantics**: The `providedFields` set in `ApplicationPatchRequest` tracks which setters were called during deserialization, enabling true partial updates where omitted fields are never touched.

- **Archive/Restore Preservation**: Restoring an archived application (`archived: false`) clears the `archivedAt` timestamp but preserves the application's status, allowing users to recover rejected/approved applications without losing their state.

- **Status Validation**: Only validates status when it's explicitly provided in the patch; existing statuses are assumed valid and not re-validated.

- **Draft State Management**: Clearing status (sending `status: null`) automatically moves the application back to "To Send Later" and clears the application date; setting a status requires an application date to be present.

- **Idempotent Archiving**: Archiving an already-archived application preserves the original `archivedAt` timestamp, making the operation safe to retry.

https://claude.ai/code/session_01UfhpX5ZAkykvvDPrScPh1u