### PR TITLE
fix(test): cascade Drive and export rows when a user is deleted

### DIFF
--- a/src/main/java/com/jobtracker/entity/GoogleDriveBaseInformation.java
+++ b/src/main/java/com/jobtracker/entity/GoogleDriveBaseInformation.java
@@ -2,6 +2,8 @@ package com.jobtracker.entity;
 
 import com.jobtracker.entity.enums.BaseInformationDocType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
@@ -30,6 +32,7 @@ public class GoogleDriveBaseInformation {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "connection_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private GoogleDriveConnection connection;
 
     @Column(name = "google_file_id", nullable = false, length = 255)

--- a/src/main/java/com/jobtracker/entity/GoogleDriveBaseResume.java
+++ b/src/main/java/com/jobtracker/entity/GoogleDriveBaseResume.java
@@ -1,6 +1,8 @@
 package com.jobtracker.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
@@ -21,6 +23,7 @@ public class GoogleDriveBaseResume {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "connection_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private GoogleDriveConnection connection;
 
     @Column(name = "google_file_id", nullable = false, length = 255)

--- a/src/main/java/com/jobtracker/entity/GoogleDriveConnection.java
+++ b/src/main/java/com/jobtracker/entity/GoogleDriveConnection.java
@@ -1,6 +1,8 @@
 package com.jobtracker.entity;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
@@ -20,8 +22,10 @@ public class GoogleDriveConnection {
     @Column(name = "id", columnDefinition = "BINARY(16)", updatable = false, nullable = false)
     private UUID id;
 
+    /** Mirrors the ON DELETE CASCADE the migration declares, so deleting a user drops the connection. */
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(name = "google_account_id", nullable = false, length = 255)

--- a/src/test/java/com/jobtracker/integration/UserDeletionCascadeIT.java
+++ b/src/test/java/com/jobtracker/integration/UserDeletionCascadeIT.java
@@ -1,0 +1,131 @@
+package com.jobtracker.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobtracker.dto.auth.RegisterRequest;
+import com.jobtracker.entity.ExportExecution;
+import com.jobtracker.entity.ExportSchedule;
+import com.jobtracker.entity.GoogleDriveBaseResume;
+import com.jobtracker.entity.GoogleDriveConnection;
+import com.jobtracker.entity.User;
+import com.jobtracker.entity.enums.ExportDestinationType;
+import com.jobtracker.entity.enums.ExportExecutionStatus;
+import com.jobtracker.entity.enums.ExportFormat;
+import com.jobtracker.entity.enums.ExportFrequency;
+import com.jobtracker.entity.enums.ExportTrigger;
+import com.jobtracker.repository.ExportExecutionRepository;
+import com.jobtracker.repository.ExportScheduleRepository;
+import com.jobtracker.repository.GoogleDriveBaseResumeRepository;
+import com.jobtracker.repository.GoogleDriveConnectionRepository;
+import com.jobtracker.repository.RefreshTokenRepository;
+import com.jobtracker.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Deleting a user must take its dependent rows with it.
+ *
+ * <p>The migrations declare {@code ON DELETE CASCADE} on these foreign keys, but tests run against
+ * a schema generated from the entity mappings — so a missing {@code @OnDelete} makes the generated
+ * schema stricter than production and any test that clears the {@code users} table starts failing
+ * as soon as another test class leaves a child row behind. This test pins the two schemas together.
+ */
+class UserDeletionCascadeIT extends AbstractIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private RefreshTokenRepository refreshTokenRepository;
+    @Autowired private GoogleDriveConnectionRepository connectionRepository;
+    @Autowired private GoogleDriveBaseResumeRepository baseResumeRepository;
+    @Autowired private ExportScheduleRepository exportScheduleRepository;
+    @Autowired private ExportExecutionRepository exportExecutionRepository;
+
+    @Test
+    void deletingAUser_shouldCascadeToDriveAndExportRows() throws Exception {
+        User user = registerUser();
+
+        GoogleDriveConnection connection = connectionRepository.save(driveConnection(user));
+        baseResumeRepository.save(baseResume(connection));
+        ExportSchedule schedule = exportScheduleRepository.save(exportSchedule(user));
+        exportExecutionRepository.save(exportExecution(user, schedule));
+
+        // Refresh tokens are cleared explicitly by every integration test, exactly as here; the
+        // Drive and export rows below are the ones that must disappear on their own.
+        refreshTokenRepository.deleteAll();
+
+        assertThatCode(() -> userRepository.deleteAll()).doesNotThrowAnyException();
+
+        assertThat(connectionRepository.count()).isZero();
+        assertThat(baseResumeRepository.count()).isZero();
+        assertThat(exportScheduleRepository.count()).isZero();
+        assertThat(exportExecutionRepository.count()).isZero();
+    }
+
+    private User registerUser() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "Cascade User", "cascade-user@example.com", "pass1234", "pass1234", true);
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+        return userRepository.findByEmail("cascade-user@example.com").orElseThrow();
+    }
+
+    private static GoogleDriveConnection driveConnection(User user) {
+        GoogleDriveConnection connection = new GoogleDriveConnection();
+        connection.setUser(user);
+        connection.setGoogleAccountId("acct-cascade");
+        connection.setGoogleEmail("cascade@gmail.com");
+        connection.setGoogleDisplayName("Cascade");
+        connection.setAccessToken("drive-access");
+        connection.setRefreshToken("drive-refresh");
+        connection.setAccessTokenExpiresAt(LocalDateTime.now().plusHours(1));
+        connection.setGrantedScopes("https://www.googleapis.com/auth/drive");
+        connection.setConnectedAt(LocalDateTime.now());
+        return connection;
+    }
+
+    private static GoogleDriveBaseResume baseResume(GoogleDriveConnection connection) {
+        GoogleDriveBaseResume resume = new GoogleDriveBaseResume();
+        resume.setConnection(connection);
+        resume.setGoogleFileId("file-cascade");
+        resume.setDocumentName("Base resume");
+        return resume;
+    }
+
+    private static ExportSchedule exportSchedule(User user) {
+        ExportSchedule schedule = new ExportSchedule();
+        schedule.setUser(user);
+        schedule.setName("Cascade backup");
+        schedule.setFormat(ExportFormat.CSV);
+        schedule.setFrequency(ExportFrequency.DAILY);
+        schedule.setTimeOfDay(LocalTime.of(20, 0));
+        schedule.setTimezone("America/Sao_Paulo");
+        schedule.setDestination(ExportDestinationType.GOOGLE_DRIVE);
+        schedule.setEnabled(true);
+        return schedule;
+    }
+
+    private static ExportExecution exportExecution(User user, ExportSchedule schedule) {
+        ExportExecution execution = new ExportExecution();
+        execution.setUser(user);
+        execution.setSchedule(schedule);
+        execution.setScheduleName(schedule.getName());
+        execution.setTrigger(ExportTrigger.SCHEDULED);
+        execution.setFormat(ExportFormat.CSV);
+        execution.setDestination(ExportDestinationType.GOOGLE_DRIVE);
+        execution.setStatus(ExportExecutionStatus.SUCCESS);
+        execution.setStartedAt(LocalDateTime.now());
+        return execution;
+    }
+}


### PR DESCRIPTION
Fixes the red `main` after #73.

## What broke

`Backend CI/CD` on `main` (`18c6a57`) failed with 31 errors — every test in `ApplicationControllerIT` and `ExportControllerIT` erroring in `setUp`:

```
DataIntegrityViolationException: Referential integrity constraint violation:
"...google_drive_connections FOREIGN KEY(user_id) REFERENCES users(id)";
SQL statement: delete from users where id=?
```

## Why

The migrations declare `ON DELETE CASCADE` for `google_drive_connections`, `google_drive_base_resumes` and `google_drive_base_information`, but the entity mappings did not. Integration tests run against a schema generated from those mappings (`ddl-auto=create-drop`), so the test schema was **stricter than production**: once any test class left a Drive connection behind, the next class calling `userRepository.deleteAll()` failed.

The export ITs added in #73 create a Drive connection, which is what exposed it. Whether the following class hit the leftover row depends on Spring context caching and the surefire class order — so the same commit passed locally and failed on CI.

## Fix

- `@OnDelete(action = OnDeleteAction.CASCADE)` on the three mappings, mirroring the migrations. Production DDL is unchanged (Flyway already declares the cascade; `ddl-auto=validate` does not check FK actions) — this only aligns the generated test schema.
- `UserDeletionCascadeIT` pins the two schemas together: it creates a user with a Drive connection, base resume, export schedule and execution, deletes the user and asserts the dependants are gone. It fails without this change.

## Verification

- `mvn -B -ntp clean verify` (the exact CI command) — 372 tests, 0 failures.
- Same suite with `-Dsurefire.runOrder=reversealphabetical` — 372 tests, 0 failures.
- `UserDeletionCascadeIT` confirmed failing on the pre-fix tree and passing after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc6icunWZA5boT47V22eyL)_