### PR TITLE
fix(test): keep the export ITs from leaking rows across test classes

### DIFF
--- a/src/test/java/com/jobtracker/e2e/ExportE2ETest.java
+++ b/src/test/java/com/jobtracker/e2e/ExportE2ETest.java
@@ -10,6 +10,7 @@ import com.jobtracker.repository.UserGamificationRepository;
 import com.jobtracker.repository.UserInterviewMetricsRepository;
 import com.jobtracker.repository.UserRepository;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,15 +39,7 @@ class ExportE2ETest extends AbstractE2ETest {
 
     @BeforeEach
     void setUp() {
-        exportExecutionRepository.deleteAll();
-        exportScheduleRepository.deleteAll();
-        userAchievementRepository.deleteAll();
-        userGamificationRepository.deleteAll();
-        interviewEventRepository.deleteAll();
-        applicationRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userInterviewMetricsRepository.deleteAll();
-        userRepository.deleteAll();
+        clearDatabase();
 
         Response register = given()
                 .contentType("application/json")
@@ -63,6 +56,28 @@ class ExportE2ETest extends AbstractE2ETest {
                 .then().statusCode(201).extract().response();
 
         accessToken = register.jsonPath().getString("accessToken");
+    }
+
+    /**
+     * Also runs after each test: this class registers a user and creates applications, and the
+     * in-memory database is shared with every other test class, so anything left behind breaks
+     * whichever class clears the users table next.
+     */
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    private void clearDatabase() {
+        exportExecutionRepository.deleteAll();
+        exportScheduleRepository.deleteAll();
+        userAchievementRepository.deleteAll();
+        userGamificationRepository.deleteAll();
+        interviewEventRepository.deleteAll();
+        applicationRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userInterviewMetricsRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/jobtracker/integration/ExportControllerIT.java
+++ b/src/test/java/com/jobtracker/integration/ExportControllerIT.java
@@ -17,6 +17,7 @@ import com.jobtracker.repository.UserRepository;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +56,23 @@ class ExportControllerIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        clearDatabase();
+
+        ownerToken = register("Export Owner", "export-owner@example.com");
+        otherToken = register("Other User", "export-other@example.com");
+    }
+
+    /**
+     * Runs before and after every test: these classes create users, applications and a Google Drive
+     * connection, and the in-memory database is shared with every other test class, so leaving rows
+     * behind would break whichever class clears the users table next.
+     */
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    private void clearDatabase() {
         exportExecutionRepository.deleteAll();
         exportScheduleRepository.deleteAll();
         userAchievementRepository.deleteAll();
@@ -65,9 +83,6 @@ class ExportControllerIT extends AbstractIntegrationTest {
         passwordResetTokenRepository.deleteAll();
         refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
-
-        ownerToken = register("Export Owner", "export-owner@example.com");
-        otherToken = register("Other User", "export-other@example.com");
     }
 
     @Test

--- a/src/test/java/com/jobtracker/integration/ExportScheduleControllerIT.java
+++ b/src/test/java/com/jobtracker/integration/ExportScheduleControllerIT.java
@@ -22,6 +22,7 @@ import com.jobtracker.repository.UserRepository;
 import com.jobtracker.integration.support.RecordingDriveApiClient;
 import com.jobtracker.service.GoogleDriveApiClient;
 import com.jobtracker.service.export.ScheduledExportExecutor;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,24 @@ class ExportScheduleControllerIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
+        clearDatabase();
+
+        ownerToken = register("Schedule Owner", "schedule-owner@example.com");
+        otherToken = register("Other User", "schedule-other@example.com");
+        owner = userRepository.findByEmail("schedule-owner@example.com").orElseThrow();
+    }
+
+    /**
+     * Runs before and after every test: these classes create users, applications and a Google Drive
+     * connection, and the in-memory database is shared with every other test class, so leaving rows
+     * behind would break whichever class clears the users table next.
+     */
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    private void clearDatabase() {
         ((RecordingDriveApiClient) googleDriveApiClient).reset();
         exportExecutionRepository.deleteAll();
         exportScheduleRepository.deleteAll();
@@ -88,10 +107,6 @@ class ExportScheduleControllerIT extends AbstractIntegrationTest {
         passwordResetTokenRepository.deleteAll();
         refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
-
-        ownerToken = register("Schedule Owner", "schedule-owner@example.com");
-        otherToken = register("Other User", "schedule-other@example.com");
-        owner = userRepository.findByEmail("schedule-owner@example.com").orElseThrow();
     }
 
     @Test

--- a/src/test/java/com/jobtracker/integration/ExportSchedulerIT.java
+++ b/src/test/java/com/jobtracker/integration/ExportSchedulerIT.java
@@ -24,6 +24,7 @@ import com.jobtracker.repository.UserInterviewMetricsRepository;
 import com.jobtracker.repository.UserRepository;
 import com.jobtracker.service.GoogleDriveApiClient;
 import com.jobtracker.service.export.ScheduledExportExecutor;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,18 +82,7 @@ class ExportSchedulerIT extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ((RecordingDriveApiClient) googleDriveApiClient).reset();
-        exportExecutionRepository.deleteAll();
-        exportScheduleRepository.deleteAll();
-        googleDriveConnectionRepository.deleteAll();
-        userAchievementRepository.deleteAll();
-        interviewEventRepository.deleteAll();
-        userInterviewMetricsRepository.deleteAll();
-        userGamificationRepository.deleteAll();
-        applicationRepository.deleteAll();
-        passwordResetTokenRepository.deleteAll();
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
+        clearDatabase();
 
         RegisterRequest register = new RegisterRequest(
                 "Scheduler Owner", "scheduler-owner@example.com", "pass1234", "pass1234", true);
@@ -107,6 +97,31 @@ class ExportSchedulerIT extends AbstractIntegrationTest {
 
         connectGoogleDrive();
         createApplication("Scheduled Vacancy");
+    }
+
+    /**
+     * Runs before and after every test: these classes create users, applications and a Google Drive
+     * connection, and the in-memory database is shared with every other test class, so leaving rows
+     * behind would break whichever class clears the users table next.
+     */
+    @AfterEach
+    void tearDown() {
+        clearDatabase();
+    }
+
+    private void clearDatabase() {
+        ((RecordingDriveApiClient) googleDriveApiClient).reset();
+        exportExecutionRepository.deleteAll();
+        exportScheduleRepository.deleteAll();
+        googleDriveConnectionRepository.deleteAll();
+        userAchievementRepository.deleteAll();
+        interviewEventRepository.deleteAll();
+        userInterviewMetricsRepository.deleteAll();
+        userGamificationRepository.deleteAll();
+        applicationRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        refreshTokenRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/jobtracker/integration/UserDeletionCascadeIT.java
+++ b/src/test/java/com/jobtracker/integration/UserDeletionCascadeIT.java
@@ -20,6 +20,7 @@ import com.jobtracker.repository.RefreshTokenRepository;
 import com.jobtracker.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -59,16 +60,22 @@ class UserDeletionCascadeIT extends AbstractIntegrationTest {
         ExportSchedule schedule = exportScheduleRepository.save(exportSchedule(user));
         exportExecutionRepository.save(exportExecution(user, schedule));
 
-        // Refresh tokens are cleared explicitly by every integration test, exactly as here; the
-        // Drive and export rows below are the ones that must disappear on their own.
-        refreshTokenRepository.deleteAll();
+        // Registration issues a refresh token, and that table has no cascade; every integration
+        // test clears it the same way. Only this user's tokens are removed, so rows belonging to
+        // other test classes are left untouched.
+        refreshTokenRepository.deleteAll(refreshTokenRepository.findAll().stream()
+                .filter(token -> user.getId().equals(token.getUser().getId()))
+                .toList());
 
-        assertThatCode(() -> userRepository.deleteAll()).doesNotThrowAnyException();
+        assertThatCode(() -> userRepository.delete(user)).doesNotThrowAnyException();
 
-        assertThat(connectionRepository.count()).isZero();
-        assertThat(baseResumeRepository.count()).isZero();
-        assertThat(exportScheduleRepository.count()).isZero();
-        assertThat(exportExecutionRepository.count()).isZero();
+        // Scoped to this user: the shared in-memory database may hold rows from other test classes.
+        assertThat(connectionRepository.findByUserId(user.getId())).isEmpty();
+        assertThat(baseResumeRepository.findAllByConnectionUserIdOrderByCreatedAtAsc(user.getId())).isEmpty();
+        assertThat(exportScheduleRepository.findAllByUserIdOrderByCreatedAtAsc(user.getId())).isEmpty();
+        assertThat(exportExecutionRepository
+                .findAllByUserIdOrderByStartedAtDesc(user.getId(), PageRequest.of(0, 1))
+                .getTotalElements()).isZero();
     }
 
     private User registerUser() throws Exception {


### PR DESCRIPTION
Fixes the `Backend CI/CD` failure on `main` at `bd7ca3e` ([run](https://github.com/vitorhugo-dotnet/SpringBoot-JobApplyTracker/actions/runs/31750474192/job/94614837145)).

## What broke

One failure, in the regression test I added in #74:

```
Tests run: 372, Failures: 1
com.jobtracker.integration.UserDeletionCascadeIT.deletingAUser_shouldCascadeToDriveAndExportRows
```

The cascade fix from #74 worked — the 31 errors it targeted are gone. The new test itself was the problem: it called `userRepository.deleteAll()`, which also deletes users left behind by *other* test classes, and those users have `job_applications` rows that (correctly) do not cascade. In isolation it passed; behind another class it failed.

## Root cause, in one line

The integration and E2E tests share one in-memory database, and the export tests cleared their tables only in `@BeforeEach` — so each class left its last test's rows for whichever class ran next.

## Fix

- `UserDeletionCascadeIT` deletes only the user it created and asserts on that user's rows, which is what the cascade behaviour is actually about.
- `ExportControllerIT`, `ExportScheduleControllerIT`, `ExportSchedulerIT` and `ExportE2ETest` now clear on the way out too, via a shared `clearDatabase()`.

## Verification

- `mvn -B -ntp clean verify` (the CI command) — 372 tests, 0 failures.
- Full suite green in **all three** class orders: `filesystem` (what CI uses), `alphabetical` and `reversealphabetical`.
- Reproduced the CI condition locally first (`-Dtest=ApplicationControllerIT,UserDeletionCascadeIT`): fails on the pre-fix tree, passes after.

An earlier revision of this description blamed the `alphabetical`-order failure in `McpToolsE2ETest` on pre-existing code. That was wrong: the leftover rows came from `ExportE2ETest`, added in #73, and the last commit here fixes it. `McpToolsE2ETest` is unchanged and now passes in every order.