### PR TITLE
Fix null status handling in gamification and application patching

### DIFF
--- a/src/main/java/com/jobtracker/service/GamificationService.java
+++ b/src/main/java/com/jobtracker/service/GamificationService.java
@@ -511,7 +511,8 @@ public class GamificationService {
     }
 
     private boolean qualifiesForInterviewProgress(JobApplication application) {
-        return application.isInterviewScheduled() || INTERVIEW_PROGRESS_STATUSES.contains(application.getStatus());
+        String status = application.getStatus();
+        return application.isInterviewScheduled() || (status != null && INTERVIEW_PROGRESS_STATUSES.contains(status));
     }
 
     private boolean qualifiesForOfferWon(JobApplication application) {

--- a/src/test/java/com/jobtracker/e2e/McpToolsE2ETest.java
+++ b/src/test/java/com/jobtracker/e2e/McpToolsE2ETest.java
@@ -6,6 +6,8 @@ import com.jobtracker.entity.enums.RoleName;
 import com.jobtracker.repository.ApplicationRepository;
 import com.jobtracker.repository.RefreshTokenRepository;
 import com.jobtracker.repository.RoleRepository;
+import com.jobtracker.repository.UserAchievementRepository;
+import com.jobtracker.repository.UserGamificationRepository;
 import com.jobtracker.repository.UserRepository;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
@@ -70,12 +72,16 @@ class McpToolsE2ETest extends AbstractE2ETest {
     @Autowired private RoleRepository roleRepository;
     @Autowired private RefreshTokenRepository refreshTokenRepository;
     @Autowired private ApplicationRepository applicationRepository;
+    @Autowired private UserGamificationRepository userGamificationRepository;
+    @Autowired private UserAchievementRepository userAchievementRepository;
 
     private String betaAccessToken;
     private String mcpSessionId;
 
     @BeforeEach
     void setUp() {
+        userAchievementRepository.deleteAll();
+        userGamificationRepository.deleteAll();
         applicationRepository.deleteAll();
         refreshTokenRepository.deleteAll();
         userRepository.deleteAll();
@@ -206,6 +212,52 @@ class McpToolsE2ETest extends AbstractE2ETest {
                 .as("List-Base-Information must be callable end-to-end for a BETA user without error: %s",
                         response.asString())
                 .isNotEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void createApplicationTool_statusAndApplicationDateOmitted_createsToSendLaterRecord() {
+        String call = """
+                {
+                  "jsonrpc": "2.0",
+                  "id": 4,
+                  "method": "tools/call",
+                  "params": {
+                    "name": "Create-Application",
+                    "arguments": {
+                      "vacancyName": "[TESTE] repro bug",
+                      "organization": "TESTE-BLOCKER",
+                      "rhAcceptedConnection": false,
+                      "interviewScheduled": false,
+                      "recruiterDmReminderEnabled": false
+                    }
+                  }
+                }
+                """;
+        Response response = given()
+                .header("Authorization", "Bearer " + betaAccessToken)
+                .header(MCP_SESSION_ID_HEADER, mcpSessionId)
+                .accept("application/json, text/event-stream")
+                .contentType("application/json")
+                .body(call)
+                .post(MCP_ENDPOINT)
+                .then().statusCode(200).extract().response();
+
+        JsonPath body = mcpJsonRpcBody(response);
+        assertThat(body.<Object>get("error"))
+                .as("Create-Application must not fail at the JSON-RPC layer when status/applicationDate "
+                        + "are omitted: %s", response.asString())
+                .isNull();
+        Boolean isError = body.getObject("result.isError", Boolean.class);
+        assertThat(isError)
+                .as("Create-Application must succeed end-to-end without status/applicationDate: %s",
+                        response.asString())
+                .isNotEqualTo(Boolean.TRUE);
+
+        String resultText = body.getString("result.content[0].text");
+        JsonPath resultBody = new JsonPath(resultText);
+        assertThat(resultBody.getBoolean("toSendLater"))
+                .as("Omitting status must create a 'To Send Later' draft record: %s", resultText)
+                .isTrue();
     }
 
     /**

--- a/src/test/java/com/jobtracker/integration/ApplicationControllerIT.java
+++ b/src/test/java/com/jobtracker/integration/ApplicationControllerIT.java
@@ -347,6 +347,20 @@ class ApplicationControllerIT extends AbstractIntegrationTest {
     }
 
     @Test
+    void patchApplication_explicitNullStatus_revertsToSendLater() throws Exception {
+        String id = createApplication("Reverting To Send Later");
+
+        mockMvc.perform(patch("/api/v1/applications/{id}", id)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\": null}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").doesNotExist())
+                .andExpect(jsonPath("$.toSendLater").value(true))
+                .andExpect(jsonPath("$.applicationDate").doesNotExist());
+    }
+
+    @Test
     void patchApplication_shouldReturn404_whenNotFound() throws Exception {
         mockMvc.perform(patch("/api/v1/applications/{id}", UUID.randomUUID())
                         .header("Authorization", "Bearer " + accessToken)


### PR DESCRIPTION
## Summary
This PR fixes issues with null status handling in the job application workflow, particularly when applications are created or reverted to "Send Later" status without an explicit status value.

## Key Changes
- **GamificationService**: Added null check for application status before checking if it qualifies for interview progress, preventing potential NullPointerException when status is null
- **ApplicationControllerIT**: Added test case to verify that explicitly setting status to null reverts an application to "Send Later" state with proper response structure
- **McpToolsE2ETest**: 
  - Added repository dependencies for `UserGamificationRepository` and `UserAchievementRepository`
  - Added cleanup of gamification and achievement data in test setup
  - Added end-to-end test case verifying that creating an application without status/applicationDate parameters correctly creates a "Send Later" draft record

## Notable Implementation Details
- The null status check in `qualifiesForInterviewProgress()` ensures the method safely handles applications in draft state (where status is null)
- Test coverage now includes the complete flow of creating applications without status information and verifying they are properly marked as "toSendLater"
- Proper test isolation is maintained by cleaning up gamification-related data in the E2E test setup

https://claude.ai/code/session_017iUSe52sWA5YeRfGScBvLQ